### PR TITLE
Be nice to msvc

### DIFF
--- a/include/spotify/json/detail/bitset.hpp
+++ b/include/spotify/json/detail/bitset.hpp
@@ -30,10 +30,10 @@ namespace detail {
 template <std::size_t inline_size>
 struct bitset {
   bitset(const std::size_t size) {
-    if (json_unlikely(size > inline_size)) {
-      _vector.reset(new std::vector<uint8_t>((size + 7) / 8));
-    } else {
+    if (json_likely(size <= inline_size)) {
       _array.fill(0x00);
+    } else {
+      _vector.reset(new std::vector<uint8_t>((size + 7) / 8));
     }
   }
 
@@ -41,13 +41,13 @@ struct bitset {
     const auto byte = (index / 8);
     const auto bidx = (index & 7);
     const auto mask = (1 << bidx);
-    if (json_unlikely(_vector)) {
-      const auto byte_before = (*_vector)[byte];
-      (*_vector)[byte] = (byte_before | mask);
-      return (byte_before & mask) >> bidx;
-    } else {
+    if (json_likely(!_vector)) {
       const auto byte_before = _array[byte];
       _array[byte] = (byte_before | mask);
+      return (byte_before & mask) >> bidx;
+    } else {
+      const auto byte_before = (*_vector)[byte];
+      (*_vector)[byte] = (byte_before | mask);
       return (byte_before & mask) >> bidx;
     }
   }

--- a/include/spotify/json/encode_context.hpp
+++ b/include/spotify/json/encode_context.hpp
@@ -51,12 +51,14 @@ struct base_encode_context final {
     std::free(_buf);
   }
 
-  json_force_inline uint8_t *reserve(const size_type num_bytes) {
+  json_force_inline uint8_t *reserve(const size_type reserved_bytes) {
     const auto remaining_bytes = static_cast<size_type>(_end - _ptr);  // _end is always >= _ptr
-    if (json_unlikely(remaining_bytes < num_bytes)) {
-      grow_buffer(num_bytes);
+    if (json_likely(remaining_bytes >= reserved_bytes)) {
+      return _ptr;
+    } else {
+      grow_buffer(reserved_bytes);
+      return _ptr;
     }
-    return _ptr;
   }
 
   json_force_inline void advance(const size_type num_bytes) {
@@ -68,13 +70,11 @@ struct base_encode_context final {
     advance(1);
   }
 
-  json_force_inline void append_or_replace(
-      const uint8_t replacing,
-      const uint8_t with) {
-    if (json_unlikely(empty() || _ptr[-1] != replacing)) {
-      append(with);
-    } else {
+  json_force_inline void append_or_replace(const uint8_t replacing, const uint8_t with) {
+    if (json_likely(!empty() && _ptr[-1] == replacing)) {
       _ptr[-1] = with;
+    } else {
+      append(with);
     }
   }
 


### PR DESCRIPTION
Reverse the order of some unlikely if-statements, to be nicer with MSVC that does not have a compiler instruction for likeliness. Instead it uses the order of the if-statements.