### PR TITLE
Rename raw_t to any_value_t and introduce encoded_value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(json_HEADERS
   include/spotify/json/encode.hpp
   include/spotify/json/encode_context.hpp
   include/spotify/json/encode_exception.hpp
+  include/spotify/json/encoded_value.hpp
   include/spotify/json/json.hpp
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(json_SOURCES
   )
 
 set(json_codec_HEADERS
-  include/spotify/json/codec/any.hpp
+  include/spotify/json/codec/any_codec.hpp
   include/spotify/json/codec/array.hpp
   include/spotify/json/codec/boolean.hpp
   include/spotify/json/codec/boost.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(json_SOURCES
 
 set(json_codec_HEADERS
   include/spotify/json/codec/any_codec.hpp
+  include/spotify/json/codec/any_value.hpp
   include/spotify/json/codec/array.hpp
   include/spotify/json/codec/boolean.hpp
   include/spotify/json/codec/boost.hpp
@@ -53,7 +54,6 @@ set(json_codec_HEADERS
   include/spotify/json/codec/object.hpp
   include/spotify/json/codec/omit.hpp
   include/spotify/json/codec/one_of.hpp
-  include/spotify/json/codec/raw.hpp
   include/spotify/json/codec/smart_ptr.hpp
   include/spotify/json/codec/string.hpp
   include/spotify/json/codec/transform.hpp

--- a/benchmark/src/benchmark_escape.cpp
+++ b/benchmark/src/benchmark_escape.cpp
@@ -46,15 +46,14 @@ std::string generate_string(size_t size, bool add_special_characters) {
 
 void check_escaped(const std::string &expected, const std::string &input) {
   encode_context context;
-  const auto begin = reinterpret_cast<const uint8_t *>(input.data());
-  write_escaped(context, begin, begin + input.size());
+  write_escaped(context, input.data(), input.data() + input.size());
   const auto x = context.size();
-  BOOST_CHECK_EQUAL(expected, std::string(reinterpret_cast<const char *>(context.data()), x));
+  BOOST_CHECK_EQUAL(expected, std::string(context.data(), x));
 }
 
 BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_simple_string) {
   const auto input = generate_string(8192, false);
-  const auto begin = reinterpret_cast<const uint8_t *>(input.data());
+  const auto begin = input.data();
 
   volatile size_t n = 0;
   JSON_BENCHMARK(1e5, [&] {
@@ -69,7 +68,7 @@ BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_simple_string) {
 
 BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_simple_string_sse42) {
   const auto input = generate_string(8192, false);
-  const auto begin = reinterpret_cast<const uint8_t *>(input.data());
+  const auto begin = input.data();
 
   volatile size_t n = 0;
   JSON_BENCHMARK(1e5, [&] {
@@ -83,7 +82,7 @@ BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_simple_string_sse42) {
 
 BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_complex_string) {
   const auto input = generate_string(8192, true);
-  const auto begin = reinterpret_cast<const uint8_t *>(input.data());
+  const auto begin = input.data();
 
   volatile size_t n = 0;
   JSON_BENCHMARK(1e5, [&] {
@@ -98,7 +97,7 @@ BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_complex_string) {
 
 BOOST_AUTO_TEST_CASE(benchmark_json_detail_write_escaped_complex_string_sse42) {
   const auto input = generate_string(8192, true);
-  const auto begin = reinterpret_cast<const uint8_t *>(input.data());
+  const auto begin = input.data();
 
   volatile size_t n = 0;
   JSON_BENCHMARK(1e5, [&] {

--- a/include/spotify/json/codec/any_codec.hpp
+++ b/include/spotify/json/codec/any_codec.hpp
@@ -29,12 +29,12 @@ namespace json {
 namespace codec {
 
 template <typename T>
-class any_t final {
+class any_codec_t final {
  public:
   using object_type = T;
 
   template <typename codec_type>
-  explicit any_t(codec_type codec)
+  explicit any_codec_t(codec_type codec)
       : _codec(std::make_shared<erased_codec_impl<codec_type>>(std::move(codec))) {}
 
   object_type decode(decode_context &context) const {
@@ -85,8 +85,8 @@ class any_t final {
 };
 
 template <typename codec_type>
-any_t<typename codec_type::object_type> any(codec_type &&codec) {
-  return any_t<typename codec_type::object_type>(std::forward<codec_type>(codec));
+any_codec_t<typename codec_type::object_type> any_codec(codec_type &&codec) {
+  return any_codec_t<typename codec_type::object_type>(std::forward<codec_type>(codec));
 }
 
 }  // namespace codec

--- a/include/spotify/json/codec/any_value.hpp
+++ b/include/spotify/json/codec/any_value.hpp
@@ -44,7 +44,7 @@ struct raw_ref {
 };
 
 template <typename T>
-class raw_t final {
+class any_value_t final {
  public:
   using object_type = T;
 
@@ -62,16 +62,16 @@ class raw_t final {
 };
 
 template <typename T>
-inline raw_t<T> raw() {
-  return raw_t<T>();
+inline any_value_t<T> any_value() {
+  return any_value_t<T>();
 }
 
 }  // namespace codec
 
 template <>
 struct default_codec_t<codec::raw_ref> {
-  static codec::raw_t<codec::raw_ref> codec() {
-    return codec::raw<codec::raw_ref>();
+  static codec::any_value_t<codec::raw_ref> codec() {
+    return codec::any_value<codec::raw_ref>();
   }
 };
 

--- a/include/spotify/json/codec/any_value.hpp
+++ b/include/spotify/json/codec/any_value.hpp
@@ -32,13 +32,13 @@ namespace codec {
 template <typename T>
 class any_value_t final {
  public:
-  using object_type = T;
+  using object_type = encoded_value<T>;
 
   object_type decode(decode_context &context) const {
     const auto begin = context.position;
     detail::skip_value(context);
-    const auto end = context.position;
-    return object_type(begin, end);
+    const auto size = context.position - begin;
+    return object_type(begin, size, typename object_type::unsafe_unchecked());
   }
 
   void encode(encode_context &context, const object_type &value) const {
@@ -54,10 +54,10 @@ inline any_value_t<T> any_value() {
 
 }  // namespace codec
 
-template <>
-struct default_codec_t<ref> {
-  static codec::any_value_t<ref> codec() {
-    return codec::any_value<ref>();
+template <typename T>
+struct default_codec_t<encoded_value<T>> {
+  static codec::any_value_t<T> codec() {
+    return codec::any_value<T>();
   }
 };
 

--- a/include/spotify/json/codec/any_value.hpp
+++ b/include/spotify/json/codec/any_value.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cstdlib>
-#include <cstring>
 
 #include <spotify/json/decode_context.hpp>
 #include <spotify/json/default_codec.hpp>
@@ -42,8 +41,7 @@ class any_value_t final {
   }
 
   void encode(encode_context &context, const object_type &value) const {
-    std::memcpy(context.reserve(value.size()), value.data(), value.size());
-    context.advance(value.size());
+    context.append(value.data(), value.size());
   }
 };
 

--- a/include/spotify/json/codec/any_value.hpp
+++ b/include/spotify/json/codec/any_value.hpp
@@ -23,25 +23,11 @@
 #include <spotify/json/default_codec.hpp>
 #include <spotify/json/detail/skip_value.hpp>
 #include <spotify/json/encode_context.hpp>
+#include <spotify/json/encoded_value.hpp>
 
 namespace spotify {
 namespace json {
 namespace codec {
-
-struct raw_ref {
-  raw_ref() : _data(nullptr), _size(0) {}
-  raw_ref(const char *data, std::size_t size) : _data(data), _size(size) {}
-  raw_ref(const char *begin, const char *end) : _data(begin), _size(end - begin) {}
-
-  explicit operator decode_context() const { return decode_context(data(), size()); }
-
-  const char *data() const { return _data; }
-  std::size_t size() const { return _size; }
-
- private:
-  const char *_data;
-  std::size_t _size;
-};
 
 template <typename T>
 class any_value_t final {
@@ -69,9 +55,9 @@ inline any_value_t<T> any_value() {
 }  // namespace codec
 
 template <>
-struct default_codec_t<codec::raw_ref> {
-  static codec::any_value_t<codec::raw_ref> codec() {
-    return codec::any_value<codec::raw_ref>();
+struct default_codec_t<ref> {
+  static codec::any_value_t<ref> codec() {
+    return codec::any_value<ref>();
   }
 };
 

--- a/include/spotify/json/codec/codec.hpp
+++ b/include/spotify/json/codec/codec.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <spotify/json/codec/any.hpp>
+#include <spotify/json/codec/any_codec.hpp>
 #include <spotify/json/codec/array.hpp>
 #include <spotify/json/codec/boolean.hpp>
 #include <spotify/json/codec/cast.hpp>

--- a/include/spotify/json/codec/codec.hpp
+++ b/include/spotify/json/codec/codec.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <spotify/json/codec/any_codec.hpp>
+#include <spotify/json/codec/any_value.hpp>
 #include <spotify/json/codec/array.hpp>
 #include <spotify/json/codec/boolean.hpp>
 #include <spotify/json/codec/cast.hpp>
@@ -31,7 +32,6 @@
 #include <spotify/json/codec/object.hpp>
 #include <spotify/json/codec/omit.hpp>
 #include <spotify/json/codec/one_of.hpp>
-#include <spotify/json/codec/raw.hpp>
 #include <spotify/json/codec/smart_ptr.hpp>
 #include <spotify/json/codec/string.hpp>
 #include <spotify/json/codec/transform.hpp>

--- a/include/spotify/json/codec/object.hpp
+++ b/include/spotify/json/codec/object.hpp
@@ -106,7 +106,7 @@ class object_t final {
     encode_context context;
     string().encode(context, key);
     context.append(':');
-    return std::string(static_cast<const char *>(context.data()), context.size());
+    return std::string(context.data(), context.size());
   }
 
   json_force_inline static void append_key_to_context(

--- a/include/spotify/json/codec/string.hpp
+++ b/include/spotify/json/codec/string.hpp
@@ -49,7 +49,7 @@ class string_t final {
     // character, but that is ok since write_escaped will not escape characters
     // with the high bit set, so the combined escaped string will contain the
     // correct UTF-8 characters in the end.
-    auto chunk_begin = reinterpret_cast<const uint8_t *>(value.data());
+    auto chunk_begin = value.data();
     const auto string_end = chunk_begin + value.size();
 
     while (chunk_begin != string_end) {

--- a/include/spotify/json/decode.hpp
+++ b/include/spotify/json/decode.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <string>
+#include <cstring>
 
 #include <spotify/json/decode_context.hpp>
 #include <spotify/json/default_codec.hpp>
@@ -25,6 +25,10 @@
 
 namespace spotify {
 namespace json {
+
+/*
+ * json::decode(codec, data...)
+ */
 
 template <typename codec_type>
 typename codec_type::object_type decode(const codec_type &codec, const char *data, size_t size) {
@@ -37,19 +41,37 @@ typename codec_type::object_type decode(const codec_type &codec, const char *dat
 }
 
 template <typename codec_type>
-typename codec_type::object_type decode(const codec_type &codec, const std::string &string) {
+typename codec_type::object_type decode(const codec_type &codec, const char *cstr) {
+  return decode(codec, cstr, std::strlen(cstr));
+}
+
+template <typename codec_type, typename string_type>
+typename codec_type::object_type decode(const codec_type &codec, const string_type &string) {
   return decode(codec, string.data(), string.size());
 }
 
-template <typename Value>
-Value decode(const char *data, size_t size) {
-  return decode(default_codec<Value>(), data, size);
+/*
+ * json::decode(data...)
+ */
+
+template <typename value_type>
+value_type decode(const char *data, size_t size) {
+  return decode(default_codec<value_type>(), data, size);
 }
 
-template <typename Value>
-Value decode(const std::string &string) {
-  return decode(default_codec<Value>(), string);
+template <typename value_type>
+value_type decode(const char *cstr) {
+  return decode(default_codec<value_type>(), cstr, std::strlen(cstr));
 }
+
+template <typename value_type, typename string_type>
+value_type decode(const string_type &string) {
+  return decode(default_codec<value_type>(), string);
+}
+
+/*
+ * json::try_decode(&object, codec, data...)
+ */
 
 template <typename codec_type>
 bool try_decode(
@@ -69,19 +91,40 @@ template <typename codec_type>
 bool try_decode(
     typename codec_type::object_type &object,
     const codec_type &codec,
-    const std::string &string) {
+    const char *cstr) {
+  return try_decode(object, codec, cstr, std::strlen(cstr));
+}
+
+template <typename codec_type, typename string_type>
+bool try_decode(
+    typename codec_type::object_type &object,
+    const codec_type &codec,
+    const string_type &string) {
   return try_decode(object, codec, string.data(), string.size());
 }
 
-template <typename Value>
-bool try_decode(Value &object, const std::string &string) {
-  return try_decode(object, default_codec<Value>(), string);
+/*
+ * json::try_decode(&object, data...)
+ */
+
+template <typename value_type>
+bool try_decode(value_type &object, const char *data, size_t size) {
+  return try_decode(object, default_codec<value_type>(), data, size);
 }
 
-template <typename Value>
-bool try_decode(Value &object, const char *data, size_t size) {
-  return try_decode(object, default_codec<Value>(), data, size);
+template <typename value_type>
+bool try_decode(value_type &object, const char *cstr) {
+  return try_decode(object, default_codec<value_type>(), cstr, std::strlen(cstr));
 }
+
+template <typename value_type, typename string_type>
+bool try_decode(value_type &object, const string_type &string) {
+  return try_decode(object, default_codec<value_type>(), string);
+}
+
+/*
+ * json::try_decode_partial(&object, codec, context)
+ */
 
 template <typename codec_type>
 bool try_decode_partial(

--- a/include/spotify/json/detail/escape.hpp
+++ b/include/spotify/json/detail/escape.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include <spotify/json/encode_context.hpp>
 #include <spotify/json/detail/macros.hpp>
 
@@ -27,14 +25,14 @@ namespace detail {
 
 void write_escaped_scalar(
     encode_context &context,
-    const uint8_t *begin,
-    const uint8_t *end);
+    const char *begin,
+    const char *end);
 
 #if defined(json_arch_x86)
 void write_escaped_sse42(
     encode_context &context,
-    const uint8_t *begin,
-    const uint8_t *end);
+    const char *begin,
+    const char *end);
 #endif  // defined(json_arch_x86)
 
 /**
@@ -47,8 +45,8 @@ void write_escaped_sse42(
  */
 json_force_inline void write_escaped(
     encode_context &context,
-    const uint8_t *begin,
-    const uint8_t *end) {
+    const char *begin,
+    const char *end) {
 #if defined(json_arch_x86)
   if (json_likely(context.has_sse42)) {
     return write_escaped_sse42(context, begin, end);

--- a/include/spotify/json/encode.hpp
+++ b/include/spotify/json/encode.hpp
@@ -30,7 +30,7 @@ template <typename codec_type>
 json_never_inline std::string encode(const codec_type &codec, const typename codec_type::object_type &object) {
   encode_context context;
   codec.encode(context, object);
-  return std::string(static_cast<const char *>(context.data()), context.size());
+  return std::string(context.data(), context.size());
 }
 
 template <typename value_type>

--- a/include/spotify/json/encode.hpp
+++ b/include/spotify/json/encode.hpp
@@ -42,7 +42,7 @@ template <typename storage_type = std::string, typename codec_type>
 json_never_inline encoded_value<storage_type> encode_value(const codec_type &codec, const typename codec_type::object_type &object) {
   encode_context context;
   codec.encode(context, object);
-  return encoded_value<storage_type>(std::move(context), typename encoded_value<storage_type>::unsafe_unchecked());
+  return encoded_value<storage_type>(context.data(), context.size(), typename encoded_value<storage_type>::unsafe_unchecked());
 }
 
 template <typename storage_type = std::string, typename value_type>

--- a/include/spotify/json/encode.hpp
+++ b/include/spotify/json/encode.hpp
@@ -21,6 +21,7 @@
 #include <spotify/json/default_codec.hpp>
 #include <spotify/json/detail/macros.hpp>
 #include <spotify/json/encode_context.hpp>
+#include <spotify/json/encoded_value.hpp>
 
 namespace spotify {
 namespace json {
@@ -35,6 +36,18 @@ json_never_inline std::string encode(const codec_type &codec, const typename cod
 template <typename value_type>
 json_never_inline std::string encode(const value_type &value) {
   return encode(default_codec<value_type>(), value);
+}
+
+template <typename storage_type = std::string, typename codec_type>
+json_never_inline encoded_value<storage_type> encode_value(const codec_type &codec, const typename codec_type::object_type &object) {
+  encode_context context;
+  codec.encode(context, object);
+  return encoded_value<storage_type>(std::move(context), typename encoded_value<storage_type>::unsafe_unchecked());
+}
+
+template <typename storage_type = std::string, typename value_type>
+json_never_inline encoded_value<storage_type> encode_value(const value_type &value) {
+  return encode_value<storage_type>(default_codec<value_type>(), value);
 }
 
 }  // namespace json

--- a/include/spotify/json/encode_context.hpp
+++ b/include/spotify/json/encode_context.hpp
@@ -38,7 +38,7 @@ template <typename size_type = std::size_t>
 struct base_encode_context final {
   base_encode_context(const size_type capacity = 4096)
       : has_sse42(detail::cpuid().has_sse42()),
-        _buf(static_cast<uint8_t *>(capacity ? std::malloc(capacity) : nullptr)),
+        _buf(static_cast<char *>(capacity ? std::malloc(capacity) : nullptr)),
         _ptr(_buf),
         _end(_buf + capacity),
         _capacity(capacity) {
@@ -51,7 +51,7 @@ struct base_encode_context final {
     std::free(_buf);
   }
 
-  json_force_inline uint8_t *reserve(const size_type reserved_bytes) {
+  json_force_inline char *reserve(const size_type reserved_bytes) {
     const auto remaining_bytes = static_cast<size_type>(_end - _ptr);  // _end is always >= _ptr
     if (json_likely(remaining_bytes >= reserved_bytes)) {
       return _ptr;
@@ -65,12 +65,12 @@ struct base_encode_context final {
     _ptr += num_bytes;
   }
 
-  json_force_inline void append(const uint8_t c) {
+  json_force_inline void append(const char c) {
     reserve(1)[0] = c;
     advance(1);
   }
 
-  json_force_inline void append_or_replace(const uint8_t replacing, const uint8_t with) {
+  json_force_inline void append_or_replace(const char replacing, const char with) {
     if (json_likely(!empty() && _ptr[-1] == replacing)) {
       _ptr[-1] = with;
     } else {
@@ -87,7 +87,7 @@ struct base_encode_context final {
     _ptr = _buf;
   }
 
-  json_force_inline const void *data() const {
+  json_force_inline const char *data() const {
     return _buf;
   }
 
@@ -127,7 +127,7 @@ struct base_encode_context final {
     // is at least as large as the reserved size. We avoid doing any arithmetics
     // here to not have to check for overflow yet again.
     const auto actual_capacity = std::max(new_size, new_capacity);
-    _buf = static_cast<uint8_t *>(std::realloc(_buf, actual_capacity));
+    _buf = static_cast<char *>(std::realloc(_buf, actual_capacity));
     if (json_unlikely(!_buf)) {
       throw std::bad_alloc();
     }
@@ -137,9 +137,9 @@ struct base_encode_context final {
     _capacity = actual_capacity;
   }
 
-  uint8_t *_buf;
-  uint8_t *_ptr;
-  const uint8_t *_end;
+  char *_buf;
+  char *_ptr;
+  const char *_end;
   size_type _capacity;
 };
 

--- a/include/spotify/json/encoded_value.hpp
+++ b/include/spotify/json/encoded_value.hpp
@@ -66,15 +66,18 @@ struct encoded_value {
       context.size(),
       unsafe_unchecked()) {}
 
-  operator storage_type const &() const & { return _json; }
-  operator storage_type &&() && { return std::move(_json); }
-
- private:
   encoded_value(const char *data, std::size_t size, const unsafe_unchecked &)
       : _json(
           reinterpret_cast<const value_type *>(data),
           reinterpret_cast<const value_type *>(data + size)) {}
 
+  operator storage_type const &() const & { return _json; }
+  operator storage_type &&() && { return std::move(_json); }
+
+  const char *data() const { return reinterpret_cast<const char *>(_json.data()); }
+  std::size_t size() const { return _json.size(); }
+
+ private:
   storage_type _json;
 };
 

--- a/include/spotify/json/encoded_value.hpp
+++ b/include/spotify/json/encoded_value.hpp
@@ -60,11 +60,6 @@ struct encoded_value {
 
   encoded_value() : encoded_value("null", 4, unsafe_unchecked()) {}
 
-  encoded_value(encode_context &&context, const unsafe_unchecked &) : encoded_value(
-      context.data(),
-      context.size(),
-      unsafe_unchecked()) {}
-
   encoded_value(const char *data, std::size_t size, const unsafe_unchecked &)
       : _json(data, data + size) {}
 

--- a/include/spotify/json/encoded_value.hpp
+++ b/include/spotify/json/encoded_value.hpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <ostream>
+
+#include <spotify/json/decode_context.hpp>
+#include <spotify/json/detail/decode_helpers.hpp>
+#include <spotify/json/detail/skip_value.hpp>
+#include <spotify/json/encode_context.hpp>
+
+namespace spotify {
+namespace json {
+
+struct ref {
+  using value_type = char;
+
+  ref(const char *data, std::size_t size)
+      : _data(data),
+        _size(size) {}
+
+  ref(const char *begin, const char *end)
+      : _data(begin),
+        _size(end - begin) {}
+
+  const char *data() const { return _data; }
+  std::size_t size() const { return _size; }
+
+ private:
+  const char *_data;
+  std::size_t _size;
+};
+
+template <typename storage_type = std::string>
+struct encoded_value {
+  using value_type = typename storage_type::value_type;
+  struct unsafe_unchecked {};
+
+  explicit encoded_value(storage_type json)
+      : _json(std::move(json)) {
+    decode_context ctx(reinterpret_cast<const char *>(_json.data()), _json.size());
+    detail::skip_value(ctx);  // validate provided JSON string
+    detail::fail_if(ctx, ctx.position != ctx.end, "Unexpected trailing input");
+  }
+
+  encoded_value() : encoded_value("null", 4, unsafe_unchecked()) {}
+
+  encoded_value(encode_context &&context, const unsafe_unchecked &) : encoded_value(
+      reinterpret_cast<const char *>(context.data()),
+      context.size(),
+      unsafe_unchecked()) {}
+
+  operator storage_type const &() const & { return _json; }
+  operator storage_type &&() && { return std::move(_json); }
+
+ private:
+  encoded_value(const char *data, std::size_t size, const unsafe_unchecked &)
+      : _json(
+          reinterpret_cast<const value_type *>(data),
+          reinterpret_cast<const value_type *>(data + size)) {}
+
+  storage_type _json;
+};
+
+template <typename storage_type>
+bool operator ==(const encoded_value<storage_type> &lhs, const storage_type &rhs) {
+  return static_cast<const storage_type &>(lhs) == rhs;
+}
+
+template <typename storage_type>
+bool operator ==(const storage_type &lhs, const encoded_value<storage_type> &rhs) {
+  return lhs == static_cast<const storage_type &>(rhs);
+}
+
+inline bool operator ==(const encoded_value<std::string> &lhs, const char *const rhs) {
+  return static_cast<const std::string &>(lhs) == rhs;
+}
+
+inline bool operator ==(const char *const lhs, const encoded_value<std::string> &rhs) {
+  return lhs == static_cast<const std::string &>(rhs);
+}
+
+template <typename storage_type>
+bool operator !=(const encoded_value<storage_type> &lhs, const storage_type &rhs) {
+  return static_cast<const storage_type &>(lhs) != rhs;
+}
+
+template <typename storage_type>
+bool operator !=(const storage_type &lhs, const encoded_value<storage_type> &rhs) {
+  return lhs != static_cast<const storage_type &>(rhs);
+}
+
+inline bool operator !=(const encoded_value<std::string> &lhs, const char *const rhs) {
+  return static_cast<const std::string &>(lhs) != rhs;
+}
+
+inline bool operator !=(const char *const lhs, const encoded_value<std::string> &rhs) {
+  return lhs != static_cast<const std::string &>(rhs);
+}
+
+template <typename storage_type>
+std::ostream &operator <<(std::ostream &stream, const encoded_value<storage_type> &value) {
+  return stream << static_cast<const storage_type &>(value);
+}
+
+}  // namespace json
+}  // namespace spotify

--- a/include/spotify/json/encoded_value.hpp
+++ b/include/spotify/json/encoded_value.hpp
@@ -49,32 +49,29 @@ struct ref {
 
 template <typename storage_type = std::string>
 struct encoded_value {
-  using value_type = typename storage_type::value_type;
   struct unsafe_unchecked {};
 
   explicit encoded_value(storage_type json)
       : _json(std::move(json)) {
-    decode_context ctx(reinterpret_cast<const char *>(_json.data()), _json.size());
-    detail::skip_value(ctx);  // validate provided JSON string
-    detail::fail_if(ctx, ctx.position != ctx.end, "Unexpected trailing input");
+    decode_context context(_json.data(), _json.size());
+    detail::skip_value(context);  // validate provided JSON string
+    detail::fail_if(context, context.position != context.end, "Unexpected trailing input");
   }
 
   encoded_value() : encoded_value("null", 4, unsafe_unchecked()) {}
 
   encoded_value(encode_context &&context, const unsafe_unchecked &) : encoded_value(
-      reinterpret_cast<const char *>(context.data()),
+      context.data(),
       context.size(),
       unsafe_unchecked()) {}
 
   encoded_value(const char *data, std::size_t size, const unsafe_unchecked &)
-      : _json(
-          reinterpret_cast<const value_type *>(data),
-          reinterpret_cast<const value_type *>(data + size)) {}
+      : _json(data, data + size) {}
 
   operator storage_type const &() const & { return _json; }
   operator storage_type &&() && { return std::move(_json); }
 
-  const char *data() const { return reinterpret_cast<const char *>(_json.data()); }
+  const char *data() const { return _json.data(); }
   std::size_t size() const { return _json.size(); }
 
  private:

--- a/include/spotify/json/json.hpp
+++ b/include/spotify/json/json.hpp
@@ -24,3 +24,4 @@
 #include <spotify/json/encode.hpp>
 #include <spotify/json/encode_exception.hpp>
 #include <spotify/json/encode_context.hpp>
+#include <spotify/json/encoded_value.hpp>

--- a/src/detail/escape.cpp
+++ b/src/detail/escape.cpp
@@ -26,8 +26,8 @@ namespace detail {
 
 void write_escaped_scalar(
     encode_context &context,
-    const uint8_t *begin,
-    const uint8_t *end) {
+    const char *begin,
+    const char *end) {
   const auto buf = context.reserve(6 * (end - begin));  // 6 is the length of \u00xx
   auto ptr = buf;
 

--- a/src/detail/escape_common.hpp
+++ b/src/detail/escape_common.hpp
@@ -29,7 +29,7 @@ namespace spotify {
 namespace json {
 namespace detail {
 
-json_force_inline void write_escaped_c(uint8_t *&out, const uint8_t c) {
+json_force_inline void write_escaped_c(char *&out, const char c) {
   static const char HEX[] = "0123456789ABCDEF";
   static const char POPULAR_CONTROL_CHARACTERS[] = {
     'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
@@ -42,7 +42,7 @@ json_force_inline void write_escaped_c(uint8_t *&out, const uint8_t c) {
   // is below 0x30 and the latter is at 0x5C. As an optimization, for most
   // simple strings (letters, numbers, some punctuation), check for this first
   // before doing more complicated checks (more expensive checks).
-  if (json_likely(c >= 0x30)) {
+  if (json_likely(uint8_t(c) >= 0x30)) {
     if (json_likely(c != '\\')) {
       *(out++) = c;
     } else {
@@ -56,7 +56,7 @@ json_force_inline void write_escaped_c(uint8_t *&out, const uint8_t c) {
   // different punctuation and special characters. We will write most of them as
   // is, except for ", which is trivially escaped. Note that JSON allows for /
   // to be escaped as well, but most JSON serializers do not.
-  if (json_likely(c >= 0x20)) {
+  if (json_likely(uint8_t(c) >= 0x20)) {
     if (json_likely(c != '"')) {
       *(out++) = c;
     } else {
@@ -70,7 +70,7 @@ json_force_inline void write_escaped_c(uint8_t *&out, const uint8_t c) {
   // to some degree. There are some "popular" control characters, such as tabs,>
   // newline, and carriage return, with simple escape codes. All other control
   // characters get an escape code on the form \u00xx. Six bytes. Isch.
-  const auto control_character = POPULAR_CONTROL_CHARACTERS[c];
+  const auto control_character = POPULAR_CONTROL_CHARACTERS[int(c)];
   if (json_likely(control_character != 'u')) {
     out[0] = '\\';
     out[1] = control_character;
@@ -83,23 +83,23 @@ json_force_inline void write_escaped_c(uint8_t *&out, const uint8_t c) {
   }
 }
 
-json_force_inline void write_escaped_1(uint8_t *&out, const uint8_t *&begin) {
-  struct blob_1_t { uint8_t a; };
+json_force_inline void write_escaped_1(char *&out, const char *&begin) {
+  struct blob_1_t { char a; };
   const auto b = *reinterpret_cast<const blob_1_t *>(begin);
   write_escaped_c(out, b.a);
   begin += sizeof(blob_1_t);
 }
 
-json_force_inline void write_escaped_2(uint8_t *&out, const uint8_t *&begin) {
-  struct blob_2_t { uint8_t a, b; };
+json_force_inline void write_escaped_2(char *&out, const char *&begin) {
+  struct blob_2_t { char a, b; };
   const auto b = *reinterpret_cast<const blob_2_t *>(begin);
   write_escaped_c(out, b.a);
   write_escaped_c(out, b.b);
   begin += sizeof(blob_2_t);
 }
 
-json_force_inline void write_escaped_4(uint8_t *&out, const uint8_t *&begin) {
-  struct blob_4_t { uint8_t a, b, c, d; };
+json_force_inline void write_escaped_4(char *&out, const char *&begin) {
+  struct blob_4_t { char a, b, c, d; };
   const auto b = *reinterpret_cast<const blob_4_t *>(begin);
   write_escaped_c(out, b.a);
   write_escaped_c(out, b.b);
@@ -108,8 +108,8 @@ json_force_inline void write_escaped_4(uint8_t *&out, const uint8_t *&begin) {
   begin += sizeof(blob_4_t);
 }
 
-json_force_inline void write_escaped_8(uint8_t *&out, const uint8_t *&begin) {
-  struct blob_8_t { uint8_t a, b, c, d, e, f, g, h; };
+json_force_inline void write_escaped_8(char *&out, const char *&begin) {
+  struct blob_8_t { char a, b, c, d, e, f, g, h; };
   const auto b = *reinterpret_cast<const blob_8_t *>(begin);
   write_escaped_c(out, b.a);
   write_escaped_c(out, b.b);

--- a/src/detail/escape_sse42.cpp
+++ b/src/detail/escape_sse42.cpp
@@ -26,7 +26,7 @@ namespace spotify {
 namespace json {
 namespace detail {
 
-json_force_inline void write_escaped_16_sse42(uint8_t *&out, const __m128i chunk) {
+json_force_inline void write_escaped_16_sse42(char *&out, const __m128i chunk) {
   write_escaped_c(out, _mm_extract_epi8(chunk, 0));
   write_escaped_c(out, _mm_extract_epi8(chunk, 1));
   write_escaped_c(out, _mm_extract_epi8(chunk, 2));
@@ -47,8 +47,8 @@ json_force_inline void write_escaped_16_sse42(uint8_t *&out, const __m128i chunk
 
 void write_escaped_sse42(
     encode_context &context,
-    const uint8_t *begin,
-    const uint8_t *end) {
+    const char *begin,
+    const char *end) {
   const auto buf = context.reserve(6 * (end - begin));  // 6 is the length of \u00xx
   auto out = buf;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(json_test_HEADERS
 
 set(json_test_SOURCES
   src/test_any_codec.cpp
+  src/test_any_value.cpp
   src/test_array.cpp
   src/test_bitset.cpp
   src/test_boolean.cpp
@@ -47,7 +48,6 @@ set(json_test_SOURCES
   src/test_object.cpp
   src/test_omit.cpp
   src/test_one_of.cpp
-  src/test_raw.cpp
   src/test_skip_chars.cpp
   src/test_skip_value.cpp
   src/test_smart_ptr.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ set(json_test_HEADERS
   )
 
 set(json_test_SOURCES
-  src/test_any.cpp
+  src/test_any_codec.cpp
   src/test_array.cpp
   src/test_bitset.cpp
   src/test_boolean.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(json_test_SOURCES
   src/test_encode_context.cpp
   src/test_encode_helpers.cpp
   src/test_encode_integer.cpp
+  src/test_encoded_value.cpp
   src/test_enumeration.cpp
   src/test_eq.cpp
   src/test_escape.cpp

--- a/test/src/test_any_codec.cpp
+++ b/test/src/test_any_codec.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <spotify/json/codec/any.hpp>
+#include <spotify/json/codec/any_codec.hpp>
 #include <spotify/json/codec/boolean.hpp>
 #include <spotify/json/encode.hpp>
 
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_SUITE(codec)
 namespace {
 
 bool any_parse(const char *str) {
-  any_t<bool> codec = any_t<bool>(boolean());
+  any_codec_t<bool> codec = any_codec_t<bool>(boolean());
   auto ctx = decode_context(str, str + strlen(str));
   const auto result = codec.decode(ctx);
 
@@ -40,7 +40,7 @@ bool any_parse(const char *str) {
 }  // namespace
 
 BOOST_AUTO_TEST_CASE(json_any_should_encode) {
-  any_t<bool> codec = any_t<bool>(boolean());
+  any_codec_t<bool> codec = any_codec_t<bool>(boolean());
   BOOST_CHECK_EQUAL(encode(codec, true), "true");
   BOOST_CHECK_EQUAL(encode(codec, false), "false");
 }
@@ -51,11 +51,11 @@ BOOST_AUTO_TEST_CASE(json_any_should_decode) {
 }
 
 BOOST_AUTO_TEST_CASE(json_any_should_construct_with_helper) {
-  any(boolean());
+  any_codec(boolean());
 }
 
 BOOST_AUTO_TEST_CASE(json_any_should_respect_should_encode) {
-  auto codec = any(only_true_t());
+  auto codec = any_codec(only_true_t());
   BOOST_CHECK(codec.should_encode(true));
   BOOST_CHECK(!codec.should_encode(false));
 }

--- a/test/src/test_any_value.cpp
+++ b/test/src/test_any_value.cpp
@@ -105,26 +105,30 @@ BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_into_vector) {
  */
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_ref_as_is) {
-  std::string data = "1234";
-  ref data_ref(data.data(), data.size());
-  BOOST_CHECK_EQUAL(encode(data_ref), data);
+  const auto sdata = std::string("1234");
+  const auto rdata = ref(sdata.data(), sdata.size());
+  const auto value = encoded_value<ref>(rdata);
+  BOOST_CHECK_EQUAL(encode(value), sdata);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_string_as_is) {
-  std::string data = "1234";
-  BOOST_CHECK_EQUAL(encode(any_value<std::string>(), data), data);
+  const auto sdata = std::string("1234");
+  const auto value = encoded_value<>(sdata);
+  BOOST_CHECK_EQUAL(encode(any_value<std::string>(), value), sdata);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_vector_as_is) {
-  std::string data = "1234";
-  std::vector<uint8_t> vec(data.data(), data.data() + data.size());
-  BOOST_CHECK_EQUAL(encode(any_value<std::vector<uint8_t>>(), vec), data);
+  const auto sdata = std::string("1234");
+  const auto vdata = std::vector<uint8_t>(sdata.data(), sdata.data() + sdata.size());
+  const auto value = encoded_value<std::vector<uint8_t>>(vdata);
+  BOOST_CHECK_EQUAL(encode(any_value<std::vector<uint8_t>>(), value), sdata);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_with_separators) {
-  std::string raw = "{}";
-  ref data_ref(raw.data(), raw.size());
-  std::vector<ref> refs{data_ref, data_ref, data_ref};
+  const auto sdata = std::string("{}");
+  const auto rdata = ref(sdata.data(), sdata.size());
+  const auto value = encoded_value<ref>(rdata);
+  const std::vector<encoded_value<ref>> refs{ value, value, value };
   BOOST_CHECK_EQUAL(encode(refs), "[{},{},{}]");
 }
 

--- a/test/src/test_any_value.cpp
+++ b/test/src/test_any_value.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_into_string) {
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_into_vector) {
-  verify_decode_any_value<std::vector<uint8_t>>("[1, 2, 3]");
+  verify_decode_any_value<std::vector<char>>("[1, 2, 3]");
 }
 
 /*
@@ -119,9 +119,9 @@ BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_string_as_is) {
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_vector_as_is) {
   const auto sdata = std::string("1234");
-  const auto vdata = std::vector<uint8_t>(sdata.data(), sdata.data() + sdata.size());
-  const auto value = encoded_value<std::vector<uint8_t>>(vdata);
-  BOOST_CHECK_EQUAL(encode(any_value<std::vector<uint8_t>>(), value), sdata);
+  const auto vdata = std::vector<char>(sdata.data(), sdata.data() + sdata.size());
+  const auto value = encoded_value<std::vector<char>>(vdata);
+  BOOST_CHECK_EQUAL(encode(any_value<std::vector<char>>(), value), sdata);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_with_separators) {

--- a/test/src/test_any_value.cpp
+++ b/test/src/test_any_value.cpp
@@ -20,9 +20,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <spotify/json/codec/any_value.hpp>
 #include <spotify/json/codec/array.hpp>
 #include <spotify/json/codec/object.hpp>
-#include <spotify/json/codec/raw.hpp>
 #include <spotify/json/decode.hpp>
 #include <spotify/json/default_codec.hpp>
 #include <spotify/json/encode.hpp>
@@ -39,8 +39,8 @@ struct foobar_t {
 };
 
 template <typename value_type = raw_ref>
-void verify_decode_raw(const std::string &raw_value) {
-  const auto codec = raw<value_type>();
+void verify_decode_any_value(const std::string &raw_value) {
+  const auto codec = any_value<value_type>();
   const auto decoded = json::decode(codec, raw_value);
   BOOST_CHECK_EQUAL(raw_value, std::string(decoded.data(), decoded.data() + decoded.size()));
 }
@@ -83,37 +83,37 @@ BOOST_AUTO_TEST_CASE(json_codec_raw_ref_should_convert_to_decode_context) {
  * Decoding
  */
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_array) {
-  verify_decode_raw("[1, 2, 3]");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_array) {
+  verify_decode_any_value("[1, 2, 3]");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_object) {
-  verify_decode_raw(R"({"hey":"yo"})");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_object) {
+  verify_decode_any_value(R"({"hey":"yo"})");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_boolean) {
-  verify_decode_raw("true");
-  verify_decode_raw("false");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_boolean) {
+  verify_decode_any_value("true");
+  verify_decode_any_value("false");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_null) {
-  verify_decode_raw("null");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_null) {
+  verify_decode_any_value("null");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_string) {
-  verify_decode_raw("\"foobar\"");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_string) {
+  verify_decode_any_value("\"foobar\"");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_number) {
-  verify_decode_raw("123");
-  verify_decode_raw("123.456");
-  verify_decode_raw("-123.456");
-  verify_decode_raw("-123.456e+45");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_number) {
+  verify_decode_any_value("123");
+  verify_decode_any_value("123.456");
+  verify_decode_any_value("-123.456");
+  verify_decode_any_value("-123.456e+45");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_deep_json) {
-  // This is deep enough to blow the stack if the raw codec is implemented using
-  // simple recursion. The failure case of this unit test is that it crashes.
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_deep_json) {
+  // This is deep enough to blow the stack if the any_value codec is implemented
+  // using simple recursion. The failure case of this test is that it crashes.
   const auto depth = 1000000;
 
   std::string str;
@@ -121,39 +121,39 @@ BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_deep_json) {
   for (auto i = 0; i < depth; i++) { str += '['; }
   for (auto i = 0; i < depth; i++) { str += ']'; }
 
-  verify_decode_raw(str);
+  verify_decode_any_value(str);
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_into_string) {
-  verify_decode_raw<std::string>("[1, 2, 3]");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_into_string) {
+  verify_decode_any_value<std::string>("[1, 2, 3]");
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_decode_into_vector) {
-  verify_decode_raw<std::vector<uint8_t>>("[1, 2, 3]");
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_into_vector) {
+  verify_decode_any_value<std::vector<uint8_t>>("[1, 2, 3]");
 }
 
 /*
  * Encoding
  */
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_encode_ref_as_is) {
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_ref_as_is) {
   std::string data = "some junk";
   raw_ref ref(data.data(), data.size());
   BOOST_CHECK_EQUAL(encode(ref), data);
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_encode_string_as_is) {
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_string_as_is) {
   std::string data = "some junk";
-  BOOST_CHECK_EQUAL(encode(raw<std::string>(), data), data);
+  BOOST_CHECK_EQUAL(encode(any_value<std::string>(), data), data);
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_encode_vector_as_is) {
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_vector_as_is) {
   std::string data = "some junk";
   std::vector<uint8_t> vec(data.data(), data.data() + data.size());
-  BOOST_CHECK_EQUAL(encode(raw<std::vector<uint8_t>>(), vec), data);
+  BOOST_CHECK_EQUAL(encode(any_value<std::vector<uint8_t>>(), vec), data);
 }
 
-BOOST_AUTO_TEST_CASE(json_codec_raw_should_encode_with_separators) {
+BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_with_separators) {
   std::string raw = "{}";
   raw_ref ref(raw.data(), raw.size());
   std::vector<raw_ref> refs{ref, ref, ref};

--- a/test/src/test_any_value.cpp
+++ b/test/src/test_any_value.cpp
@@ -38,46 +38,14 @@ struct foobar_t {
   value_type value;
 };
 
-template <typename value_type = raw_ref>
-void verify_decode_any_value(const std::string &raw_value) {
+template <typename value_type = ref>
+void verify_decode_any_value(const std::string &json) {
   const auto codec = any_value<value_type>();
-  const auto decoded = json::decode(codec, raw_value);
-  BOOST_CHECK_EQUAL(raw_value, std::string(decoded.data(), decoded.data() + decoded.size()));
+  const auto decoded = json::decode(codec, json);
+  BOOST_CHECK_EQUAL(json, std::string(decoded.data(), decoded.data() + decoded.size()));
 }
 
 }  // namespace
-
-/*
- * Constructing
- */
-
-BOOST_AUTO_TEST_CASE(json_codec_raw_ref_should_construct_from_data_size) {
-  std::string raw = "true";
-  raw_ref ref(raw.data(), raw.size());
-
-  BOOST_CHECK_EQUAL(ref.data(), raw.data());
-  BOOST_CHECK_EQUAL(ref.size(), raw.size());
-}
-
-BOOST_AUTO_TEST_CASE(json_codec_raw_ref_should_construct_from_begin_end) {
-  std::string raw = "true";
-  raw_ref ref(raw.data(), raw.data() + raw.size());
-
-  BOOST_CHECK_EQUAL(ref.data(), raw.data());
-  BOOST_CHECK_EQUAL(ref.size(), raw.size());
-}
-
-BOOST_AUTO_TEST_CASE(json_codec_raw_ref_should_convert_to_decode_context) {
-  std::string raw = "true";
-  raw_ref ref(raw.data(), raw.size());
-  decode_context context(ref);
-
-  const auto begin = raw.data();
-  const auto end = begin + raw.size();
-  BOOST_CHECK_EQUAL(context.begin, begin);
-  BOOST_CHECK_EQUAL(context.position, begin);
-  BOOST_CHECK_EQUAL(context.end, end);
-}
 
 /*
  * Decoding
@@ -137,26 +105,26 @@ BOOST_AUTO_TEST_CASE(json_codec_any_value_should_decode_into_vector) {
  */
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_ref_as_is) {
-  std::string data = "some junk";
-  raw_ref ref(data.data(), data.size());
-  BOOST_CHECK_EQUAL(encode(ref), data);
+  std::string data = "1234";
+  ref data_ref(data.data(), data.size());
+  BOOST_CHECK_EQUAL(encode(data_ref), data);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_string_as_is) {
-  std::string data = "some junk";
+  std::string data = "1234";
   BOOST_CHECK_EQUAL(encode(any_value<std::string>(), data), data);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_vector_as_is) {
-  std::string data = "some junk";
+  std::string data = "1234";
   std::vector<uint8_t> vec(data.data(), data.data() + data.size());
   BOOST_CHECK_EQUAL(encode(any_value<std::vector<uint8_t>>(), vec), data);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_any_value_should_encode_with_separators) {
   std::string raw = "{}";
-  raw_ref ref(raw.data(), raw.size());
-  std::vector<raw_ref> refs{ref, ref, ref};
+  ref data_ref(raw.data(), raw.size());
+  std::vector<ref> refs{data_ref, data_ref, data_ref};
   BOOST_CHECK_EQUAL(encode(refs), "[{},{},{}]");
 }
 

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -21,6 +21,7 @@
 #include <spotify/json/codec/number.hpp>
 #include <spotify/json/codec/object.hpp>
 #include <spotify/json/decode.hpp>
+#include <spotify/json/encoded_value.hpp>
 
 BOOST_AUTO_TEST_SUITE(spotify)
 BOOST_AUTO_TEST_SUITE(json)
@@ -60,13 +61,33 @@ BOOST_AUTO_TEST_CASE(json_decode_should_decode_from_bytes) {
   BOOST_CHECK_EQUAL(val, 53);
 }
 
-BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_string_with_custom_codec) {
+BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_cstring_with_custom_codec) {
   const auto obj = decode(custom_codec(), R"({"a":"g"})");
   BOOST_CHECK_EQUAL(obj.val, "g");
 }
 
-BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_string) {
+BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_cstring) {
   const auto obj = decode<custom_obj>(R"({"x":"h"})");
+  BOOST_CHECK_EQUAL(obj.val, "h");
+}
+
+BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_std_string_with_custom_codec) {
+  const auto obj = decode(custom_codec(), std::string(R"({"a":"g"})"));
+  BOOST_CHECK_EQUAL(obj.val, "g");
+}
+
+BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_std_string) {
+  const auto obj = decode<custom_obj>(std::string(R"({"x":"h"})"));
+  BOOST_CHECK_EQUAL(obj.val, "h");
+}
+
+BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_encoded_value_with_custom_codec) {
+  const auto obj = decode(custom_codec(), encoded_value<>(R"({"a":"g"})"));
+  BOOST_CHECK_EQUAL(obj.val, "g");
+}
+
+BOOST_AUTO_TEST_CASE(json_decode_should_encode_from_encoded_value) {
+  const auto obj = decode<custom_obj>(encoded_value<>(R"({"x":"h"})"));
   BOOST_CHECK_EQUAL(obj.val, "h");
 }
 
@@ -117,15 +138,39 @@ BOOST_AUTO_TEST_CASE(json_try_decode_should_not_decode_from_invalid_bytes) {
   BOOST_CHECK_EQUAL(val, 12);
 }
 
-BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_string_with_custom_codec) {
+BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_cstring_with_custom_codec) {
   custom_obj obj;
   BOOST_CHECK(try_decode(obj, custom_codec(), R"({"a":"g"})"));
   BOOST_CHECK_EQUAL(obj.val, "g");
 }
 
-BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_string) {
+BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_cstring) {
   custom_obj obj;
   BOOST_CHECK(try_decode(obj, R"({"x":"h"})"));
+  BOOST_CHECK_EQUAL(obj.val, "h");
+}
+
+BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_std_string_with_custom_codec) {
+  custom_obj obj;
+  BOOST_CHECK(try_decode(obj, custom_codec(), std::string(R"({"a":"g"})")));
+  BOOST_CHECK_EQUAL(obj.val, "g");
+}
+
+BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_std_string) {
+  custom_obj obj;
+  BOOST_CHECK(try_decode(obj, std::string(R"({"x":"h"})")));
+  BOOST_CHECK_EQUAL(obj.val, "h");
+}
+
+BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_encoded_value_with_custom_codec) {
+  custom_obj obj;
+  BOOST_CHECK(try_decode(obj, custom_codec(), encoded_value<>(R"({"a":"g"})")));
+  BOOST_CHECK_EQUAL(obj.val, "g");
+}
+
+BOOST_AUTO_TEST_CASE(json_try_decode_should_encode_from_encoded_value) {
+  custom_obj obj;
+  BOOST_CHECK(try_decode(obj, encoded_value<>(R"({"x":"h"})")));
   BOOST_CHECK_EQUAL(obj.val, "h");
 }
 

--- a/test/src/test_decode_context.cpp
+++ b/test/src/test_decode_context.cpp
@@ -30,9 +30,9 @@ BOOST_AUTO_TEST_CASE(json_decode_context_should_construct_with_begin_end) {
   const char * const end = string + sizeof(string);
   const decode_context ctx(string, end);
 
-  BOOST_CHECK_EQUAL(ctx.begin, string);
-  BOOST_CHECK_EQUAL(ctx.position, string);
-  BOOST_CHECK_EQUAL(ctx.end, end);
+  BOOST_CHECK(ctx.begin == string);
+  BOOST_CHECK(ctx.position == string);
+  BOOST_CHECK(ctx.end == end);
 }
 
 BOOST_AUTO_TEST_CASE(json_decode_context_should_construct_with_data_size) {
@@ -40,9 +40,9 @@ BOOST_AUTO_TEST_CASE(json_decode_context_should_construct_with_data_size) {
   const char * const end = string + sizeof(string);
   const decode_context ctx(string, sizeof(string));
 
-  BOOST_CHECK_EQUAL(ctx.begin, string);
-  BOOST_CHECK_EQUAL(ctx.position, string);
-  BOOST_CHECK_EQUAL(ctx.end, end);
+  BOOST_CHECK(ctx.begin == string);
+  BOOST_CHECK(ctx.position == string);
+  BOOST_CHECK(ctx.end == end);
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // detail

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -38,8 +38,8 @@ codec::object_t<custom_obj> custom_codec() {
   return codec;
 }
 
-std::vector<uint8_t> string_to_vector(const std::string &string) {
-  return std::vector<uint8_t>(string.begin(), string.end());
+std::vector<char> string_to_vector(const std::string &string) {
+  return std::vector<char>(string.begin(), string.end());
 }
 
 }
@@ -88,13 +88,13 @@ BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_string) {
 BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_vector_with_custom_codec) {
   custom_obj obj;
   obj.val = "c";
-  BOOST_CHECK(encode_value<std::vector<uint8_t>>(custom_codec(), obj) == string_to_vector(R"({"a":"c"})"));
+  BOOST_CHECK(encode_value<std::vector<char>>(custom_codec(), obj) == string_to_vector(R"({"a":"c"})"));
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_vector) {
   custom_obj obj;
   obj.val = "d";
-  BOOST_CHECK(encode_value<std::vector<uint8_t>>(obj) == string_to_vector(R"({"x":"d"})"));
+  BOOST_CHECK(encode_value<std::vector<char>>(obj) == string_to_vector(R"({"x":"d"})"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // json

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <string>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -37,6 +38,10 @@ codec::object_t<custom_obj> custom_codec() {
   return codec;
 }
 
+std::vector<uint8_t> string_to_vector(const std::string &string) {
+  return std::vector<uint8_t>(string.begin(), string.end());
+}
+
 }
 
 template <>
@@ -48,6 +53,10 @@ struct default_codec_t<custom_obj> {
   }
 };
 
+/*
+ * json::encode
+ */
+
 BOOST_AUTO_TEST_CASE(json_encode_should_encode_into_string_with_custom_codec) {
   custom_obj obj;
   obj.val = "c";
@@ -58,6 +67,34 @@ BOOST_AUTO_TEST_CASE(json_encode_should_encode_into_string) {
   custom_obj obj;
   obj.val = "d";
   BOOST_CHECK_EQUAL(encode(obj), R"({"x":"d"})");
+}
+
+/*
+ * json::encode_value
+ */
+
+BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_string_with_custom_codec) {
+  custom_obj obj;
+  obj.val = "c";
+  BOOST_CHECK_EQUAL(encode_value(custom_codec(), obj), R"({"a":"c"})");
+}
+
+BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_string) {
+  custom_obj obj;
+  obj.val = "d";
+  BOOST_CHECK_EQUAL(encode_value(obj), R"({"x":"d"})");
+}
+
+BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_vector_with_custom_codec) {
+  custom_obj obj;
+  obj.val = "c";
+  BOOST_CHECK(encode_value<std::vector<uint8_t>>(custom_codec(), obj) == string_to_vector(R"({"a":"c"})"));
+}
+
+BOOST_AUTO_TEST_CASE(json_encode_value_should_encode_into_vector) {
+  custom_obj obj;
+  obj.val = "d";
+  BOOST_CHECK(encode_value<std::vector<uint8_t>>(obj) == string_to_vector(R"({"x":"d"})"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // json

--- a/test/src/test_encode_context.cpp
+++ b/test/src/test_encode_context.cpp
@@ -61,9 +61,9 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_return_same_address_for_multiple
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_advance_pointer_after_reservation) {
   encode_context ctx(0);
-  ctx.advance(0); BOOST_CHECK(ctx.reserve(1024) == &static_cast<const uint8_t *>(ctx.data())[0]);
-  ctx.advance(1); BOOST_CHECK(ctx.reserve(1024) == &static_cast<const uint8_t *>(ctx.data())[1]);
-  ctx.advance(2); BOOST_CHECK(ctx.reserve(1024) == &static_cast<const uint8_t *>(ctx.data())[3]);
+  ctx.advance(0); BOOST_CHECK(ctx.reserve(1024) == &ctx.data()[0]);
+  ctx.advance(1); BOOST_CHECK(ctx.reserve(1024) == &ctx.data()[1]);
+  ctx.advance(2); BOOST_CHECK(ctx.reserve(1024) == &ctx.data()[3]);
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_maintain_correct_size_when_advancing) {
@@ -81,8 +81,8 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_append_single_byte) {
   encode_context ctx;
   ctx.append('1');
   ctx.append('2');
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[0], '1');
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[1], '2');
+  BOOST_CHECK_EQUAL(ctx.data()[0], '1');
+  BOOST_CHECK_EQUAL(ctx.data()[1], '2');
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_replace_last_byte) {
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_replace_last_byte) {
   ctx.append('1');
   ctx.append_or_replace('1', '2');
   BOOST_REQUIRE_EQUAL(ctx.size(), 1);
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[0], '2');
+  BOOST_CHECK_EQUAL(ctx.data()[0], '2');
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_not_replace_wrong_last_byte) {
@@ -98,22 +98,22 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_not_replace_wrong_last_byte) {
   ctx.append('1');
   ctx.append_or_replace('3', '2');
   BOOST_REQUIRE_EQUAL(ctx.size(), 2);
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[0], '1');
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[1], '2');
+  BOOST_CHECK_EQUAL(ctx.data()[0], '1');
+  BOOST_CHECK_EQUAL(ctx.data()[1], '2');
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_not_replace_in_empty_context) {
   encode_context ctx;
   ctx.append_or_replace('1', '2');
   BOOST_REQUIRE_EQUAL(ctx.size(), 1);
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[0], '2');
+  BOOST_CHECK_EQUAL(ctx.data()[0], '2');
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_append_multiple_bytes) {
   encode_context ctx;
   ctx.append("12", 3);
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[0], '1');
-  BOOST_CHECK_EQUAL(static_cast<const char *>(ctx.data())[1], '2');
+  BOOST_CHECK_EQUAL(ctx.data()[0], '1');
+  BOOST_CHECK_EQUAL(ctx.data()[1], '2');
 }
 
 BOOST_AUTO_TEST_CASE(json_encode_context_should_throw_exception_on_small_size_overflow) {

--- a/test/src/test_encode_integer.cpp
+++ b/test/src/test_encode_integer.cpp
@@ -33,8 +33,7 @@ template <typename T>
 void verify_encode_one_negative(encode_context &context, T value) {
   encode_negative_integer(context, value);
   context.append(0);  // null terminator for std::strtoll
-  const auto begin = static_cast<const char *>(context.data());
-  const auto encoded_value = std::strtoll(begin, nullptr, 10);
+  const auto encoded_value = std::strtoll(context.data(), nullptr, 10);
   BOOST_REQUIRE_EQUAL(value, encoded_value);
   context.clear();
 }
@@ -43,8 +42,7 @@ template <typename T>
 void verify_encode_one_positive(encode_context &context, T value) {
   encode_positive_integer(context, value);
   context.append(0);  // null terminator for std::strtoull
-  const auto begin = static_cast<const char *>(context.data());
-  const auto encoded_value = std::strtoull(begin, nullptr, 10);
+  const auto encoded_value = std::strtoull(context.data(), nullptr, 10);
   BOOST_REQUIRE_EQUAL(value, encoded_value);
   context.clear();
 }

--- a/test/src/test_encoded_value.cpp
+++ b/test/src/test_encoded_value.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -36,10 +37,10 @@ ref string_to_ref(const char *string_in_memory) {
   return ref(string_in_memory, string_in_memory + std::strlen(string_in_memory));
 }
 
-encode_context string_to_context(const std::string &string) {
-  encode_context context;
+encode_context &&string_to_context(encode_context &context, const std::string &string) {
+  context.clear();
   context.append(string.data(), string.size());
-  return context;
+  return std::move(context);
 }
 
 void take_rvalue_string(std::string &&string) {
@@ -82,9 +83,10 @@ BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_ref) {
 }
 
 BOOST_AUTO_TEST_CASE(json_encoded_value_should_not_validate_encode_context) {
-  encoded_value<>(string_to_context("[ null, 1234 ]"), encoded_value<>::unsafe_unchecked());
-  encoded_value<>(string_to_context("{ null, 1234 }"), encoded_value<>::unsafe_unchecked());
-  encoded_value<>(string_to_context("[ null, 123 ] "), encoded_value<>::unsafe_unchecked());
+  encode_context context;
+  encoded_value<>(string_to_context(context, "[ null, 1234 ]"), encoded_value<>::unsafe_unchecked());
+  encoded_value<>(string_to_context(context, "{ null, 1234 }"), encoded_value<>::unsafe_unchecked());
+  encoded_value<>(string_to_context(context, "[ null, 123 ] "), encoded_value<>::unsafe_unchecked());
 }
 
 BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_string) {

--- a/test/src/test_encoded_value.cpp
+++ b/test/src/test_encoded_value.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2016 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include <spotify/json/decode_exception.hpp>
+#include <spotify/json/encoded_value.hpp>
+
+BOOST_AUTO_TEST_SUITE(spotify)
+BOOST_AUTO_TEST_SUITE(json)
+
+namespace {
+
+template <typename value_type>
+std::vector<value_type> string_to_vector(const std::string &string) {
+  return std::vector<value_type>(string.begin(), string.end());
+}
+
+ref string_to_ref(const char *string_in_memory) {
+  return ref(string_in_memory, string_in_memory + std::strlen(string_in_memory));
+}
+
+encode_context string_to_context(const std::string &string) {
+  encode_context context;
+  context.append(string.data(), string.size());
+  return context;
+}
+
+void take_rvalue_string(std::string &&string) {
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_string) {
+  encoded_value<> value;
+  BOOST_CHECK_EQUAL(std::string(value), "null");
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_uint_vector) {
+  encoded_value<std::vector<uint8_t>> value;
+  BOOST_CHECK(std::vector<uint8_t>(value) == string_to_vector<uint8_t>("null"));
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_char_vector) {
+  encoded_value<std::vector<char>> value;
+  BOOST_CHECK(std::vector<char>(value) == string_to_vector<char>("null"));
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_ref) {
+  encoded_value<ref> value;
+  BOOST_CHECK(!memcmp(ref(value).data(), "null", 4));
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_string) {
+  encoded_value<>("[ null, 1234 ]");
+  BOOST_CHECK_THROW(encoded_value<>("{ null, 1234 }"), decode_exception);
+  BOOST_CHECK_THROW(encoded_value<>("[ null, 123 ] "), decode_exception);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_uint_vector) {
+  using vector_value = encoded_value<std::vector<uint8_t>>;
+  vector_value(string_to_vector<uint8_t>("[ null, 1234 ]"));
+  BOOST_CHECK_THROW(vector_value(string_to_vector<uint8_t>("{ null, 1234 }")), decode_exception);
+  BOOST_CHECK_THROW(vector_value(string_to_vector<uint8_t>("[ null, 123 ] ")), decode_exception);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_char_vector) {
+  using vector_value = encoded_value<std::vector<char>>;
+  vector_value(string_to_vector<char>("[ null, 1234 ]"));
+  BOOST_CHECK_THROW(vector_value(string_to_vector<char>("{ null, 1234 }")), decode_exception);
+  BOOST_CHECK_THROW(vector_value(string_to_vector<char>("[ null, 123 ] ")), decode_exception);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_ref) {
+  encoded_value<ref>(string_to_ref("[ null, 1234 ]"));
+  BOOST_CHECK_THROW(encoded_value<ref>(string_to_ref("{ null, 1234 }")), decode_exception);
+  BOOST_CHECK_THROW(encoded_value<ref>(string_to_ref("[ null, 123 ] ")), decode_exception);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_not_validate_encode_context) {
+  encoded_value<>(string_to_context("[ null, 1234 ]"), encoded_value<>::unsafe_unchecked());
+  encoded_value<>(string_to_context("{ null, 1234 }"), encoded_value<>::unsafe_unchecked());
+  encoded_value<>(string_to_context("[ null, 123 ] "), encoded_value<>::unsafe_unchecked());
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_string) {
+  const auto json = std::string("[ null, 1234 ]");
+  const encoded_value<> value(json);
+  const std::string string = value;
+  BOOST_CHECK_EQUAL(string, json);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_uint_vector) {
+  const auto json = string_to_vector<uint8_t>("[ null, 1234 ]");
+  const encoded_value<std::vector<uint8_t>> value(json);
+  const std::vector<uint8_t> vector = value;
+  BOOST_CHECK(vector == json);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_char_vector) {
+  const auto json = string_to_vector<char>("[ null, 1234 ]");
+  const encoded_value<std::vector<char>> value(json);
+  const std::vector<char> vector = value;
+  BOOST_CHECK(vector == json);
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_ref) {
+  const auto json = string_to_ref("[ null, 1234 ]");
+  const encoded_value<ref> value(json);
+  const ref data_ref = value;
+  BOOST_CHECK(data_ref.data() == json.data());
+  BOOST_CHECK(data_ref.size() == json.size());
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_move_to_string) {
+  const auto json = std::string("[ null, 1234 ]");
+  encoded_value<> value(json);
+  take_rvalue_string(std::move(value));
+}
+
+BOOST_AUTO_TEST_SUITE_END()  // json
+BOOST_AUTO_TEST_SUITE_END()  // spotify

--- a/test/src/test_encoded_value.cpp
+++ b/test/src/test_encoded_value.cpp
@@ -16,7 +16,6 @@
 
 #include <cstring>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -37,14 +36,7 @@ ref string_to_ref(const char *string_in_memory) {
   return ref(string_in_memory, string_in_memory + std::strlen(string_in_memory));
 }
 
-encode_context &&string_to_context(encode_context &context, const std::string &string) {
-  context.clear();
-  context.append(string.data(), string.size());
-  return std::move(context);
-}
-
-void take_rvalue_string(std::string &&string) {
-}
+void take_rvalue_string(std::string &&string) {}
 
 }  // namespace
 
@@ -82,11 +74,8 @@ BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_ref) {
   BOOST_CHECK_THROW(encoded_value<ref>(string_to_ref("[ null, 123 ] ")), decode_exception);
 }
 
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_not_validate_encode_context) {
-  encode_context context;
-  encoded_value<>(string_to_context(context, "[ null, 1234 ]"), encoded_value<>::unsafe_unchecked());
-  encoded_value<>(string_to_context(context, "{ null, 1234 }"), encoded_value<>::unsafe_unchecked());
-  encoded_value<>(string_to_context(context, "[ null, 123 ] "), encoded_value<>::unsafe_unchecked());
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_not_validate_unsafe_unchecked) {
+  encoded_value<>("nil", 3, encoded_value<>::unsafe_unchecked());
 }
 
 BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_string) {

--- a/test/src/test_encoded_value.cpp
+++ b/test/src/test_encoded_value.cpp
@@ -135,5 +135,17 @@ BOOST_AUTO_TEST_CASE(json_encoded_value_should_move_to_string) {
   take_rvalue_string(std::move(value));
 }
 
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_forward_data_call) {
+  const auto json = string_to_ref("[ null, 1234 ]");
+  const encoded_value<ref> value(json);
+  BOOST_CHECK(json.data() == value.data());
+}
+
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_forward_size_call) {
+  const auto json = string_to_ref("[ null, 1234 ]");
+  const encoded_value<ref> value(json);
+  BOOST_CHECK(json.size() == value.size());
+}
+
 BOOST_AUTO_TEST_SUITE_END()  // json
 BOOST_AUTO_TEST_SUITE_END()  // spotify

--- a/test/src/test_encoded_value.cpp
+++ b/test/src/test_encoded_value.cpp
@@ -28,9 +28,8 @@ BOOST_AUTO_TEST_SUITE(json)
 
 namespace {
 
-template <typename value_type>
-std::vector<value_type> string_to_vector(const std::string &string) {
-  return std::vector<value_type>(string.begin(), string.end());
+std::vector<char> string_to_vector(const std::string &string) {
+  return std::vector<char>(string.begin(), string.end());
 }
 
 ref string_to_ref(const char *string_in_memory) {
@@ -53,14 +52,9 @@ BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_string) {
   BOOST_CHECK_EQUAL(std::string(value), "null");
 }
 
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_uint_vector) {
-  encoded_value<std::vector<uint8_t>> value;
-  BOOST_CHECK(std::vector<uint8_t>(value) == string_to_vector<uint8_t>("null"));
-}
-
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_char_vector) {
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_vector) {
   encoded_value<std::vector<char>> value;
-  BOOST_CHECK(std::vector<char>(value) == string_to_vector<char>("null"));
+  BOOST_CHECK(std::vector<char>(value) == string_to_vector("null"));
 }
 
 BOOST_AUTO_TEST_CASE(json_encoded_value_should_default_construct_ref) {
@@ -74,18 +68,11 @@ BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_string) {
   BOOST_CHECK_THROW(encoded_value<>("[ null, 123 ] "), decode_exception);
 }
 
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_uint_vector) {
-  using vector_value = encoded_value<std::vector<uint8_t>>;
-  vector_value(string_to_vector<uint8_t>("[ null, 1234 ]"));
-  BOOST_CHECK_THROW(vector_value(string_to_vector<uint8_t>("{ null, 1234 }")), decode_exception);
-  BOOST_CHECK_THROW(vector_value(string_to_vector<uint8_t>("[ null, 123 ] ")), decode_exception);
-}
-
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_char_vector) {
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_vector) {
   using vector_value = encoded_value<std::vector<char>>;
-  vector_value(string_to_vector<char>("[ null, 1234 ]"));
-  BOOST_CHECK_THROW(vector_value(string_to_vector<char>("{ null, 1234 }")), decode_exception);
-  BOOST_CHECK_THROW(vector_value(string_to_vector<char>("[ null, 123 ] ")), decode_exception);
+  vector_value(string_to_vector("[ null, 1234 ]"));
+  BOOST_CHECK_THROW(vector_value(string_to_vector("{ null, 1234 }")), decode_exception);
+  BOOST_CHECK_THROW(vector_value(string_to_vector("[ null, 123 ] ")), decode_exception);
 }
 
 BOOST_AUTO_TEST_CASE(json_encoded_value_should_validate_ref) {
@@ -107,15 +94,8 @@ BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_string) {
   BOOST_CHECK_EQUAL(string, json);
 }
 
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_uint_vector) {
-  const auto json = string_to_vector<uint8_t>("[ null, 1234 ]");
-  const encoded_value<std::vector<uint8_t>> value(json);
-  const std::vector<uint8_t> vector = value;
-  BOOST_CHECK(vector == json);
-}
-
-BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_char_vector) {
-  const auto json = string_to_vector<char>("[ null, 1234 ]");
+BOOST_AUTO_TEST_CASE(json_encoded_value_should_implicitly_cast_to_vector) {
+  const auto json = string_to_vector("[ null, 1234 ]");
   const encoded_value<std::vector<char>> value(json);
   const std::vector<char> vector = value;
   BOOST_CHECK(vector == json);

--- a/test/src/test_escape.cpp
+++ b/test/src/test_escape.cpp
@@ -32,9 +32,8 @@ using namespace boost;
 
 void check_escaped(const std::string &expected, const std::string &input) {
   encode_context context;
-  const auto begin = reinterpret_cast<const uint8_t *>(input.data());
-  write_escaped(context, begin, begin + input.size());
-  BOOST_CHECK_EQUAL(expected, std::string(reinterpret_cast<const char *>(context.data()), context.size()));
+  write_escaped(context, input.data(), input.data() + input.size());
+  BOOST_CHECK_EQUAL(expected, std::string(context.data(), context.size()));
 }
 
 BOOST_AUTO_TEST_CASE(json_write_escaped_should_escape_special_characters) {


### PR DESCRIPTION
As described in #16, but without changing the return type of `json::encode`. Instead I introduced a new function `json::encode_value` that returns an `encoded_value`. The reason for this is that I ran into what I believe is a bug in the Clang compiler, getting confused about which implicit conversion operator to pick when one of them returns a const reference and the other one a non-const rvalue reference. The code compiled fine on GCC (and ICC). I tried so so many things, but ended up simply making two functions. Even if Clang would fix this in the next version, we still want to maintain compatibility with (somewhat) older compilers.