### PR TITLE
Make it possible to use `encoded_value` in a `boost::optional`

### DIFF
--- a/include/spotify/json/codec/boost.hpp
+++ b/include/spotify/json/codec/boost.hpp
@@ -69,7 +69,8 @@ class optional_t final {
     return _inner_codec.decode(context);
   }
 
-  void encode(encode_context &context, const object_type &value) const {
+  template <typename value_type>
+  void encode(encode_context &context, const boost::optional<value_type> &value) const {
     detail::fail_if(context, !value, "Cannot encode uninitialized optional");
     _inner_codec.encode(context, *value);
   }

--- a/include/spotify/json/codec/boost.hpp
+++ b/include/spotify/json/codec/boost.hpp
@@ -75,9 +75,15 @@ class optional_t final {
     _inner_codec.encode(context, *value);
   }
 
-  bool should_encode(const object_type &value) const {
+  template <typename value_type>
+  bool should_encode(const boost::optional<value_type> &value) const {
     return (value != boost::none) && detail::should_encode(_inner_codec, *value);
   }
+
+  bool should_encode(const boost::none_t &) const {
+    return false;
+  }
+
 
  private:
   codec_type _inner_codec;

--- a/include/spotify/json/codec/object.hpp
+++ b/include/spotify/json/codec/object.hpp
@@ -115,11 +115,11 @@ class object_t final {
     context.append(escaped_key.data(), escaped_key.size());
   }
 
-  template <typename codec_type>
+  template <typename codec_type, typename value_type>
   json_force_inline static void append_val_to_context(
       encode_context &context,
       const codec_type &codec,
-      const typename codec_type::object_type &value) {
+      const value_type &value) {
     codec.encode(context, value);
     context.append(',');
   }

--- a/include/spotify/json/detail/encode_helpers.hpp
+++ b/include/spotify/json/detail/encode_helpers.hpp
@@ -55,15 +55,15 @@ struct has_should_encode_method {
   static constexpr bool value = std::is_same<decltype(test<T>(0)), std::true_type>::value;
 };
 
-template <typename codec_type>
+template <typename codec_type, typename value_type>
 typename std::enable_if<!has_should_encode_method<codec_type>::value, bool>::type
-json_force_inline should_encode(const codec_type &codec, const typename codec_type::object_type &value) {
+json_force_inline should_encode(const codec_type &codec, const value_type &value) {
   return true;
 }
 
-template <typename codec_type>
+template <typename codec_type, typename value_type>
 typename std::enable_if<has_should_encode_method<codec_type>::value, bool>::type
-json_force_inline should_encode(const codec_type &codec, const typename codec_type::object_type &value) {
+json_force_inline should_encode(const codec_type &codec, const value_type &value) {
   return codec.should_encode(value);
 }
 

--- a/include/spotify/json/encode.hpp
+++ b/include/spotify/json/encode.hpp
@@ -26,26 +26,26 @@
 namespace spotify {
 namespace json {
 
-template <typename codec_type>
+template <typename codec_type, typename object_type>
 json_never_inline std::string encode(
     const codec_type &codec,
-    const typename codec_type::object_type &object) {
+    const object_type &object) {
   encode_context context;
   codec.encode(context, object);
   return std::string(context.data(), context.size());
 }
 
-template <typename value_type>
-json_never_inline std::string encode(const value_type &value) {
-  return encode(default_codec<value_type>(), value);
+template <typename object_type>
+json_never_inline std::string encode(const object_type &object) {
+  return encode(default_codec<object_type>(), object);
 }
 
-template <typename codec_type>
+template <typename codec_type, typename value_type>
 json_never_inline encoded_value encode_value(
     const codec_type &codec,
-    const typename codec_type::object_type &object) {
+    const value_type &value) {
   encode_context context;
-  codec.encode(context, object);
+  codec.encode(context, value);
   return encoded_value(std::move(context), encoded_value::unsafe_unchecked());
 }
 

--- a/test/src/test_boost.cpp
+++ b/test/src/test_boost.cpp
@@ -155,6 +155,26 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value) {
   BOOST_CHECK(encode(value) == "{}");
 }
 
+BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref_in_object) {
+  struct object_type { boost::optional<encoded_value_ref> value = encoded_value_ref("{}"); };
+  codec::object_t<object_type> codec;
+  codec.optional("value", &object_type::value);
+
+  const object_type value{};
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_in_object) {
+  struct object_type { boost::optional<encoded_value> value = encoded_value("{}"); };
+  codec::object_t<object_type> codec;
+  codec.optional("value", &object_type::value);
+
+  const object_type value{};
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
+}
+
 /*
  * boost::chrono
  */

--- a/test/src/test_boost.cpp
+++ b/test/src/test_boost.cpp
@@ -49,6 +49,9 @@ codec::object_t<sub_class> sub_codec() {
   return codec::object<sub_class>();
 }
 
+struct optional_value_ref { boost::optional<encoded_value_ref> value = encoded_value_ref("{}"); };
+struct optional_value { boost::optional<encoded_value> value = encoded_value("{}"); };
+
 }  // namespace
 
 /*
@@ -158,22 +161,20 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value) {
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref_in_object) {
-  struct object_type { boost::optional<encoded_value_ref> value = encoded_value_ref("{}"); };
-  codec::object_t<object_type> codec;
-  codec.optional("value", &object_type::value);
+  codec::object_t<optional_value_ref> codec;
+  codec.optional("value", &optional_value_ref::value);
 
-  const object_type value{};
+  const optional_value_ref value{};
   BOOST_CHECK(detail::should_encode(codec, value));
   BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
   BOOST_CHECK(decode(codec, "{\"value\":{}}").value.get() == value.value.get());
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_in_object) {
-  struct object_type { boost::optional<encoded_value> value = encoded_value("{}"); };
-  codec::object_t<object_type> codec;
-  codec.optional("value", &object_type::value);
+  codec::object_t<optional_value> codec;
+  codec.optional("value", &optional_value::value);
 
-  const object_type value{};
+  const optional_value value{};
   BOOST_CHECK(detail::should_encode(codec, value));
   BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
   BOOST_CHECK(decode(codec, "{\"value\":{}}").value.get() == value.value.get());

--- a/test/src/test_boost.cpp
+++ b/test/src/test_boost.cpp
@@ -146,6 +146,7 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref) 
   const auto codec = default_codec<boost::optional<encoded_value_ref>>();
   BOOST_CHECK(detail::should_encode(codec, value));
   BOOST_CHECK(encode(value) == "{}");
+  BOOST_CHECK(decode(codec, "{}").get() == value.get());
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value) {
@@ -153,6 +154,7 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value) {
   const auto codec = default_codec<boost::optional<encoded_value>>();
   BOOST_CHECK(detail::should_encode(codec, value));
   BOOST_CHECK(encode(value) == "{}");
+  BOOST_CHECK(decode(codec, "{}").get() == value.get());
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref_in_object) {
@@ -163,6 +165,7 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref_i
   const object_type value{};
   BOOST_CHECK(detail::should_encode(codec, value));
   BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
+  BOOST_CHECK(decode(codec, "{\"value\":{}}").value.get() == value.value.get());
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_in_object) {
@@ -173,6 +176,7 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_in_ob
   const object_type value{};
   BOOST_CHECK(detail::should_encode(codec, value));
   BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
+  BOOST_CHECK(decode(codec, "{\"value\":{}}").value.get() == value.value.get());
 }
 
 /*

--- a/test/src/test_boost.cpp
+++ b/test/src/test_boost.cpp
@@ -20,12 +20,14 @@
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <spotify/json/codec/any_value.hpp>
 #include <spotify/json/codec/boost.hpp>
 #include <spotify/json/codec/object.hpp>
 #include <spotify/json/codec/omit.hpp>
 #include <spotify/json/codec/string.hpp>
 #include <spotify/json/decode.hpp>
 #include <spotify/json/encode.hpp>
+#include <spotify/json/encoded_value.hpp>
 
 #include <spotify/json/test/only_true.hpp>
 
@@ -137,6 +139,14 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_implement_should_encode) {
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_forward_should_encode) {
   const auto codec = codec::optional_t<codec::omit_t<std::string>>(codec::omit<std::string>());
   BOOST_CHECK(!codec.should_encode(boost::make_optional(std::string(""))));
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref) {
+  BOOST_CHECK(encode(boost::optional<encoded_value_ref>(encoded_value_ref("{}"))) == "{}");
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value) {
+  BOOST_CHECK(encode(boost::optional<encoded_value>(encoded_value("{}"))) == "{}");
 }
 
 /*

--- a/test/src/test_boost.cpp
+++ b/test/src/test_boost.cpp
@@ -142,11 +142,17 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_forward_should_encode) {
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value_ref) {
-  BOOST_CHECK(encode(boost::optional<encoded_value_ref>(encoded_value_ref("{}"))) == "{}");
+  const auto value = boost::optional<encoded_value_ref>(encoded_value_ref("{}"));
+  const auto codec = default_codec<boost::optional<encoded_value_ref>>();
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(value) == "{}");
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_accept_encoded_value) {
-  BOOST_CHECK(encode(boost::optional<encoded_value>(encoded_value("{}"))) == "{}");
+  const auto value = boost::optional<encoded_value>(encoded_value("{}"));
+  const auto codec = default_codec<boost::optional<encoded_value>>();
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(value) == "{}");
 }
 
 /*


### PR DESCRIPTION
Not possible today, because the `any_value_t` codec is the default codec for `encoded_value`, but its `object_type` is `encoded_value_ref`. `encoded_value` can implicitly convert to a `encoded_value_ref` (and the other way around), but that is not true when they are wrapped in `boost::optional`. That's sad. Also, we need it to for some of our state restore use cases.