### PR TITLE
Do not build double-conversions shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ endif()
 # They also don't pass ASan at the moment.
 set(BUILD_TESTING OFF)
 
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(vendor/double-conversion)
 
 if(WIN32)


### PR DESCRIPTION
* spotify-json only requires static libraries to
link against