### PR TITLE
Fix performance problem due to uninitialized variable

### DIFF
--- a/include/spotify/json/detail/stack.hpp
+++ b/include/spotify/json/detail/stack.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Spotify AB
+ * Copyright (c) 2016-2017 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,7 +54,7 @@ struct stack {
  private:
   std::array<T, inline_capacity> _array;
   std::unique_ptr<std::vector<T>> _vector;
-  std::size_t _inline_size;
+  std::size_t _inline_size = 0;
 };
 
 }  // namespace detail


### PR DESCRIPTION
This bug has been here for some time, but hasn't been caught by
tests or in production, because if the value of this unsigned
variable is less than the inline size, then we use parts of the
inline buffer before switching to a heap allocated buffer. If
we instead get a random value that is way larger than the
inline size, then we immediately switch over to the heap
allocated vector. I would guess that the latter case is the most
common one.