### PR TITLE
Fix incorrect decoding of Unicode surrogate pairs

### DIFF
--- a/include/spotify/json/codec/string.hpp
+++ b/include/spotify/json/codec/string.hpp
@@ -122,10 +122,10 @@ class string_t final {
     const auto c = decode_hex_nibble(context, *(context.position++));
     const auto d = decode_hex_nibble(context, *(context.position++));
     const auto p = unsigned((a << 12) | (b << 8) | (c << 4) | d);
-    encode_utf8(context, out, p);
+    encode_utf8(out, p);
   }
 
-  static void encode_utf8(decode_context &context, std::string &out, unsigned p) {
+  static void encode_utf8(std::string &out, unsigned p) {
     if (json_likely(p <= 0x7F)) {
       encode_utf8_1(out, p);
     } else if (json_likely(p <= 0x07FF)) {

--- a/include/spotify/json/detail/decode_helpers.hpp
+++ b/include/spotify/json/detail/decode_helpers.hpp
@@ -80,6 +80,18 @@ json_force_inline char peek(const decode_context &context) {
   return (context.remaining() ? peek_unchecked(context) : 0);
 }
 
+/**
+ * Returns true if the next two characters are `first` and `second`.
+ * Returns false if the characters do not match, or if there is less than 2
+ * characters remaining.
+ */
+json_force_inline bool peek_2(const decode_context &context, const char first, const char second) {
+  if (context.remaining() < 2) {
+    return false;
+  }
+  return first == *context.position && second == *(context.position + 1);
+}
+
 json_force_inline char next_unchecked(decode_context &context) {
   return *(context.position++);
 }

--- a/include/spotify/json/detail/decode_helpers.hpp
+++ b/include/spotify/json/detail/decode_helpers.hpp
@@ -55,9 +55,7 @@ json_force_inline void fail_if(
 }
 
 template <size_t num_required_bytes, typename string_type>
-json_force_inline void require_bytes(
-    const decode_context &context,
-    const string_type &error = "Unexpected end of input") {
+json_force_inline void require_bytes(const decode_context &context, const string_type &error) {
   fail_if(context, context.remaining() < num_required_bytes, error);
 }
 

--- a/test/src/test_decode_helpers.cpp
+++ b/test/src/test_decode_helpers.cpp
@@ -74,6 +74,23 @@ BOOST_AUTO_TEST_CASE(json_decode_helpers_peek) {
   BOOST_CHECK_EQUAL(peek(make_context("ab")), 'a');
 }
 
+BOOST_AUTO_TEST_CASE(json_decode_helpers_peek_2) {
+  BOOST_CHECK(peek_2(make_context("ab"), 'a', 'b'));
+  BOOST_CHECK(peek_2(make_context("abcd"), 'a', 'b'));
+}
+
+BOOST_AUTO_TEST_CASE(json_decode_helpers_peek_2_nonmatching) {
+  BOOST_CHECK(!peek_2(make_context("aa"), 'a', 'b'));
+  BOOST_CHECK(!peek_2(make_context("bb"), 'a', 'b'));
+  BOOST_CHECK(!peek_2(make_context("aab"), 'a', 'b'));
+}
+
+BOOST_AUTO_TEST_CASE(json_decode_helpers_peek_2_too_short) {
+  BOOST_CHECK(!peek_2(make_context(""), 'a', 'b'));
+  BOOST_CHECK(!peek_2(make_context("a"), 'a', 'b'));
+  BOOST_CHECK(!peek_2(make_context("b"), 'a', 'b'));
+}
+
 /*
  * Next
  */


### PR DESCRIPTION
For example, the JSON string `"\ud83d\udc95"` should result in `"💕"` when decoded.