### PR TITLE
Fix issues encoding/decoding strings with null bytes

### DIFF
--- a/src/detail/escape_sse42.cpp
+++ b/src/detail/escape_sse42.cpp
@@ -53,7 +53,7 @@ void write_escaped_sse42(
   auto out = buf;
 
   const __m128i ranges = _mm_setr_epi8(
-    0x01, 0x1F,  // control characters
+    0x00, 0x1F,  // null byte & control characters
     0x22, 0x22,  // double quotation mark
     0x5C, 0x5C,  // reverse solidus (backslash)
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -66,7 +66,7 @@ void write_escaped_sse42(
 
   for (; end - begin >= 16; begin += 16) {
     const __m128i chunk = _mm_load_si128(reinterpret_cast<const __m128i *>(begin));
-    const unsigned has_character_in_ranges = _mm_cmpistrc(ranges, chunk, _SIDD_CMP_RANGES);
+    const unsigned has_character_in_ranges = _mm_cmpestrc(ranges, 6, chunk, 16, _SIDD_CMP_RANGES);
     if (json_likely(!has_character_in_ranges)) {
       _mm_storeu_si128(reinterpret_cast<__m128i *>(out), chunk);
       out += 16;

--- a/src/detail/skip_chars_sse42.cpp
+++ b/src/detail/skip_chars_sse42.cpp
@@ -42,7 +42,7 @@ void skip_any_simple_characters_sse42(decode_context &context) {
     for (; end - pos >= 16; pos += 16) {
       const auto chunk = _mm_load_si128(reinterpret_cast<const __m128i *>(pos));
       constexpr auto flags = _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_POSITIVE_POLARITY | _SIDD_LEAST_SIGNIFICANT;
-      const auto index = _mm_cmpistri(chars, chunk, flags);
+      const auto index = _mm_cmpestri(chars, 2, chunk, 16, flags);
       if (index != 16) {
         context.position = pos + index;
         return;
@@ -74,7 +74,7 @@ void skip_any_whitespace_sse42(decode_context &context) {
   for (; end - pos >= 16; pos += 16) {
     const auto chunk = _mm_load_si128(reinterpret_cast<const __m128i *>(pos));
     constexpr auto flags = _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_NEGATIVE_POLARITY | _SIDD_LEAST_SIGNIFICANT;
-    const auto index = _mm_cmpistri(chars, chunk, flags);
+    const auto index = _mm_cmpestri(chars, 4, chunk, 16, flags);
     if (index != 16) {
       context.position = pos + index;
       return;

--- a/test/src/test_skip_chars.cpp
+++ b/test/src/test_skip_chars.cpp
@@ -82,6 +82,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(json_skip_any_simple_characters, use_sse, true_fal
   }
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(json_skip_any_simple_characters_null_byte_in_string,
+                              use_sse,
+                              true_false) {
+  alignas(16) char input_data[17] = "a\0\"\"\"\"\"\"\"\"\"\"\"\"\"\"";
+  auto context = decode_context(input_data, input_data + 16);
+  *const_cast<bool *>(&context.has_sse42) &= use_sse::value;
+  skip_any_simple_characters(context);
+  BOOST_CHECK_EQUAL(context.position - input_data, 2);
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(json_skip_any_simple_characters_with_empty_string,
                               use_sse,
                               true_false) {


### PR DESCRIPTION
The `_mm_cmpistrc` intrinsic considers the null byte to mean end-of-string, but we want the `_mm_cmpestri` where the string lengths are set explicitly.