### PR TITLE
enable -Wunused-parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,12 @@ matrix:
         - VALGRIND=valgrind --leak-check=full
     - os: osx
       compiler: clang
+      env:
+        - Boost_NO_BOOST_CMAKE=ON
     - os: osx
       compiler: gcc
+      env:
+        - Boost_NO_BOOST_CMAKE=ON
 
 install: source .travis/install_${TRAVIS_OS_NAME}.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ matrix:
     - os: osx
       compiler: clang
       env:
-        - Boost_NO_BOOST_CMAKE=ON
+        - CMAKEOPT=-DBoost_NO_BOOST_CMAKE=ON
     - os: osx
       compiler: gcc
       env:
-        - Boost_NO_BOOST_CMAKE=ON
+        - CMAKEOPT=-DBoost_NO_BOOST_CMAKE=ON
 
 install: source .travis/install_${TRAVIS_OS_NAME}.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ set(json_library_TARGET "spotify-json")
 add_library(${json_library_TARGET} STATIC ${json_all_HEADERS} ${json_all_SOURCES})
 target_include_directories(${json_library_TARGET} PUBLIC ${json_INCLUDE_DIR})
 
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+  target_compile_options(${json_library_TARGET} PRIVATE "-Wunused-parameter")
+endif()
+
 if(WIN32)
   target_compile_options(${json_library_TARGET} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
 endif()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -37,6 +37,10 @@ add_executable(${json_benchmark_TARGET} ${json_benchmark_SOURCES} ${json_benchma
 set_property(TARGET ${json_benchmark_TARGET} PROPERTY CXX_STANDARD 11)
 set_property(TARGET ${json_benchmark_TARGET} PROPERTY CXX_STANDARD_REQUIRED ON)
 
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+  target_compile_options(${json_benchmark_TARGET} PRIVATE "-Wunused-parameter")
+endif()
+
 if(WIN32)
   target_compile_options(${json_benchmark_TARGET} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
 endif()

--- a/include/spotify/json/codec/eq.hpp
+++ b/include/spotify/json/codec/eq.hpp
@@ -48,7 +48,7 @@ class eq_t final {
     return result;
   }
 
-  void encode(encode_context &context, const object_type &value) const {
+  void encode(encode_context &context, const object_type & /*value*/) const {
     _inner_codec.encode(context, _value);
   }
 

--- a/include/spotify/json/codec/ignore.hpp
+++ b/include/spotify/json/codec/ignore.hpp
@@ -38,11 +38,11 @@ class ignore_t final {
     return _value;
   }
 
-  void encode(encode_context &context, const object_type &value) const {
+  void encode(encode_context &context, const object_type & /*value*/) const {
     detail::fail(context, "ignore_t codec cannot encode");
   }
 
-  bool should_encode(const object_type &value) const {
+  bool should_encode(const object_type & /*value*/) const {
     return false;
   }
 

--- a/include/spotify/json/codec/null.hpp
+++ b/include/spotify/json/codec/null.hpp
@@ -42,7 +42,7 @@ class null_t final {
     return _value;
   }
 
-  void encode(encode_context &context, const object_type value) const {
+  void encode(encode_context &context, const object_type /*value*/) const {
     context.append("null", 4);
   }
 

--- a/include/spotify/json/codec/number.hpp
+++ b/include/spotify/json/codec/number.hpp
@@ -182,7 +182,7 @@ json_force_inline T exp_10(
  */
 template <typename T, bool is_positive>
 json_never_inline T decode_integer_range_with_overflow(
-    decode_context &context,
+    decode_context & /*context*/,
     const char *begin,
     const char *end,
     const T initial_value,

--- a/include/spotify/json/codec/object.hpp
+++ b/include/spotify/json/codec/object.hpp
@@ -119,13 +119,13 @@ class object_t final {
     context.append(',');
   }
 
-  T construct(std::true_type is_default_constructible) const {
+  T construct(std::true_type /*is_default_constructible*/) const {
     // Avoid the cost of an std::function invocation if no construct function
     // is provided.
     return _construct ? _construct() : object_type();
   }
 
-  T construct(std::false_type is_default_constructible) const {
+  T construct(std::false_type /*is_default_constructible*/) const {
     // T is not default constructible. Because _construct must be set if T is
     // not default constructible, there is no reason to test it in this case.
     return _construct();
@@ -157,14 +157,14 @@ class object_t final {
         : field(required, required_field_idx),
           codec(std::move(codec)) {}
 
-    void decode(decode_context &context, object_type &object) const override {
+    void decode(decode_context &context, object_type & /*object*/) const override {
       codec.decode(context);
     }
 
     void encode(
         encode_context &context,
         const std::string &escaped_key,
-        const object_type &object) const override {
+        const object_type & /*object*/) const override {
       const auto &value = typename codec_type::object_type();
       if (json_likely(detail::should_encode(codec, value))) {
         append_key_to_context(context, escaped_key);

--- a/include/spotify/json/codec/omit.hpp
+++ b/include/spotify/json/codec/omit.hpp
@@ -36,11 +36,11 @@ class omit_t final {
     detail::fail(context, "omit_t codec cannot decode");
   }
 
-  void encode(encode_context &context, const object_type &value) const {
+  void encode(encode_context &context, const object_type & /*value*/) const {
     detail::fail(context, "omit_t codec cannot encode");
   }
 
-  bool should_encode(const object_type &value) const {
+  bool should_encode(const object_type & /*value*/) const {
     return false;
   }
 };

--- a/include/spotify/json/codec/tuple.hpp
+++ b/include/spotify/json/codec/tuple.hpp
@@ -59,8 +59,8 @@ struct tuple_field final {
 
 template <typename T, typename... codecs_type>
 struct tuple_field<T, 0, codecs_type...> {
-  static void decode(const std::tuple<codecs_type...> &codecs, decode_context &, T &) {}
-  static void encode(const std::tuple<codecs_type...> &codecs, encode_context &, const T &) {}
+  static void decode(const std::tuple<codecs_type...> & /*codecs*/, decode_context &, T &) {}
+  static void encode(const std::tuple<codecs_type...> & /*codecs*/, encode_context &, const T &) {}
 };
 
 }

--- a/include/spotify/json/detail/encode_helpers.hpp
+++ b/include/spotify/json/detail/encode_helpers.hpp
@@ -26,7 +26,7 @@ namespace detail {
 
 template <typename string_type>
 json_never_inline json_noreturn void fail(
-    const encode_context &context,
+    const encode_context & /*context*/,
     const string_type &error) {
   throw encode_exception(error);
 }
@@ -57,7 +57,7 @@ struct has_should_encode_method {
 
 template <typename codec_type, typename value_type>
 typename std::enable_if<!has_should_encode_method<codec_type>::value, bool>::type
-json_force_inline should_encode(const codec_type &codec, const value_type &value) {
+json_force_inline should_encode(const codec_type & /*codec*/, const value_type & /*value*/) {
   return true;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,10 @@ add_executable(${spotify_json_test_TARGET} ${spotify_json_test_SOURCES} ${spotif
 set_property(TARGET ${spotify_json_test_TARGET} PROPERTY CXX_STANDARD 11)
 set_property(TARGET ${spotify_json_test_TARGET} PROPERTY CXX_STANDARD_REQUIRED ON)
 
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+  target_compile_options(${spotify_json_test_TARGET} PRIVATE "-Wunused-parameter")
+endif()
+
 if(WIN32)
   target_compile_options(${spotify_json_test_TARGET} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
 endif()

--- a/test/include/spotify/json/test/only_true.hpp
+++ b/test/include/spotify/json/test/only_true.hpp
@@ -30,11 +30,11 @@ class only_true_t final {
  public:
   using object_type = bool;
 
-  object_type decode(decode_context &context) const {
+  object_type decode(decode_context & /*context*/) const {
     return object_type();
   }
 
-  void encode(encode_context &context, const object_type &value) const {
+  void encode(encode_context &context, const object_type & /*value*/) const {
     _bool_codec.encode(context, true);
   }
 

--- a/test/src/test_cast.cpp
+++ b/test/src/test_cast.cpp
@@ -35,7 +35,7 @@ class dummy_t final {
  public:
   using object_type = T;
 
-  object_type decode(decode_context &context) const {
+  object_type decode(decode_context & /*context*/) const {
     return new T();
   }
 };

--- a/test/src/test_decode_helpers.cpp
+++ b/test/src/test_decode_helpers.cpp
@@ -395,7 +395,7 @@ bool decode_boolean(decode_context &context) {
 BOOST_AUTO_TEST_CASE(json_decode_helpers_decode_empty_object) {
   auto ctx = make_context("{}");
   const auto original_ctx = ctx;
-  decode_object<codec::omit_t<bool>>(ctx, [&](bool &&key) {
+  decode_object<codec::omit_t<bool>>(ctx, [&](bool && /*key*/) {
     BOOST_CHECK(!"Should not be called");
   });
   BOOST_CHECK(ctx.position == original_ctx.end);
@@ -449,28 +449,28 @@ BOOST_AUTO_TEST_CASE(json_decode_helpers_decode_object_with_whitespace) {
 
 BOOST_AUTO_TEST_CASE(json_decode_helpers_decode_object_with_broken_key) {
   auto ctx = make_context("{tru:false}");
-  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool &&key) {
+  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool && /*key*/) {
     BOOST_CHECK(!"Should not be called");
   }), decode_exception);
 }
 
 BOOST_AUTO_TEST_CASE(json_decode_helpers_decode_object_with_broken_value) {
   auto ctx = make_context("{true:fals}");
-  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool &&key) {
+  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool && /*key*/) {
     decode_boolean(ctx);
   }), decode_exception);
 }
 
 BOOST_AUTO_TEST_CASE(json_decode_helpers_decode_object_without_colon) {
   auto ctx = make_context("{truefalse}");
-  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool &&key) {
+  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool && /*key*/) {
     BOOST_CHECK(!"Should not be called");
   }), decode_exception);
 }
 
 BOOST_AUTO_TEST_CASE(json_decode_helpers_decode_object_without_ending_brace) {
   auto ctx = make_context("{true:false");
-  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool &&key) {
+  BOOST_CHECK_THROW(decode_object<codec::boolean_t>(ctx, [&](bool && /*key*/) {
     decode_boolean(ctx);
   }), decode_exception);
 }


### PR DESCRIPTION
Public headers of spotify-json contain unused parameters. This fact makes it hard for users to enable `-Wunused-parameter` for their projects.

This PR is (more or less) an automatically generated fix for the clang-tidy warning [misc-unused-parameters ](https://clang.llvm.org/extra/clang-tidy/checks/misc-unused-parameters.html). It is generated by means of...

```BASH
mkdir build
cd build
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja ..
run-clang-tidy-7 -p . -checks misc-unused-parameters -header-filter ".*spotify.*"  -fix
```
... and relies on compile database. Since `test_umbrella.cpp` (indirectly) includes all public headers, I hope all function signatures were fixed.

**UPDATE**

spotify_json_test is not built on macOS, because cmake cannot detect the boost installation. It is because `find_package(Boost ...)` starting from boost version 1.70 relies on the presence of file `BoostConfig.cmake` by default. Homebrew installation (macOS) seems not to provide it. The recommended solution from...

https://github.com/Homebrew/homebrew-core/issues/44093

... is to set Boost_NO_BOOST_CMAKE=ON.

How it looks without this option:

```
==> Upgrading 1 outdated package:
boost 1.67.0_1 -> 1.71.0
==> Upgrading boost 
==> Installing dependencies for boost: icu4c
==> Installing boost dependency: icu4c
 ...
 -- Could NOT find Boost: missing: chrono unit_test_framework system (found /usr/local/lib/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0"))
 -- Specify BOOST_ROOT (and possibly BOOST_LIBRARYDIR) to build unit tests and benchmarks.
 ... 
0.01s$ ${VALGRIND} ./test/spotify_json_test
/Users/travis/.travis/functions: line 109: ./test/spotify_json_test: No such file or directory
The command "${VALGRIND} ./test/spotify_json_test" exited with 127.
```

