### PR TITLE
Several changes to reduce the binary size of apps using this library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(json_detail_HEADERS
   )
 
 set(json_detail_SOURCES
+  src/detail/bitset.cpp
   src/detail/decode_helpers.cpp
   src/detail/encode_helpers.cpp
   src/detail/encode_integer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(json_codec_HEADERS
 set(json_codec_SOURCES
   src/codec/boolean.cpp
   src/codec/number.cpp
+  src/codec/object.cpp
   src/codec/string.cpp
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(json_codec_HEADERS
 
 set(json_codec_SOURCES
   src/codec/boolean.cpp
+  src/codec/number.cpp
   src/codec/string.cpp
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(json_HEADERS
 
 set(json_SOURCES
   src/decode_exception.cpp
+  src/encode_exception.cpp
   )
 
 set(json_codec_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(json_HEADERS
   )
 
 set(json_SOURCES
+  src/decode_context.cpp
   src/decode_exception.cpp
   src/encode_exception.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(json_HEADERS
   )
 
 set(json_SOURCES
+  src/decode_exception.cpp
   )
 
 set(json_codec_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(json_detail_HEADERS
   )
 
 set(json_detail_SOURCES
+  src/detail/decode_helpers.cpp
   src/detail/encode_helpers.cpp
   src/detail/encode_integer.cpp
   src/detail/escape.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(json_codec_HEADERS
   )
 
 set(json_codec_SOURCES
+  src/codec/boolean.cpp
   src/codec/string.cpp
   )
 
@@ -117,6 +118,10 @@ set(json_all_SOURCES
 source_group(spotify\\json         FILES ${json_HEADERS})
 source_group(spotify\\json\\codec  FILES ${json_codec_HEADERS})
 source_group(spotify\\json\\detail FILES ${json_detail_HEADERS})
+source_group(spotify\\json         FILES ${json_SOURCES})
+source_group(spotify\\json\\codec  FILES ${json_codec_SOURCES})
+source_group(spotify\\json\\detail FILES ${json_detail_SOURCES})
+source_group(spotify\\json\\detail FILES ${json_detail_SSE42_SOURCES})
 
 set(json_library_TARGET "spotify-json")
 add_library(${json_library_TARGET} STATIC ${json_all_HEADERS} ${json_all_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(json_SOURCES
   src/decode_exception.cpp
   src/encode_context.cpp
   src/encode_exception.cpp
+  src/encoded_value.cpp
   )
 
 set(json_codec_HEADERS
@@ -63,6 +64,10 @@ set(json_codec_HEADERS
   include/spotify/json/codec/string.hpp
   include/spotify/json/codec/transform.hpp
   include/spotify/json/codec/tuple.hpp
+  )
+
+set(json_codec_SOURCES
+  src/codec/string.cpp
   )
 
 set(json_detail_HEADERS
@@ -104,6 +109,7 @@ set(json_all_HEADERS
 
 set(json_all_SOURCES
   ${json_SOURCES}
+  ${json_codec_SOURCES}
   ${json_detail_SOURCES}
   ${json_detail_SSE42_SOURCES}
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2016 Spotify AB
+# Copyright (c) 2014-2019 Spotify AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -76,6 +76,7 @@ set(json_detail_HEADERS
   )
 
 set(json_detail_SOURCES
+  src/detail/encode_helpers.cpp
   src/detail/encode_integer.cpp
   src/detail/escape.cpp
   src/detail/escape_common.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(json_HEADERS
 set(json_SOURCES
   src/decode_context.cpp
   src/decode_exception.cpp
+  src/encode_context.cpp
   src/encode_exception.cpp
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(json_codec_HEADERS
   )
 
 set(json_codec_SOURCES
+  src/codec/any_value.cpp
   src/codec/boolean.cpp
   src/codec/number.cpp
   src/codec/object.cpp

--- a/include/spotify/json/codec/any_codec.hpp
+++ b/include/spotify/json/codec/any_codec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Spotify AB
+ * Copyright (c) 2015-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,6 @@
 
 #include <memory>
 #include <utility>
-
 #include <spotify/json/decode_context.hpp>
 #include <spotify/json/detail/decode_helpers.hpp>
 #include <spotify/json/detail/encode_helpers.hpp>
@@ -34,8 +33,8 @@ class any_codec_t final {
   using object_type = T;
 
   template <typename codec_type>
-  explicit any_codec_t(codec_type codec)
-      : _codec(std::make_shared<erased_codec_impl<codec_type>>(std::move(codec))) {}
+  explicit any_codec_t(codec_type &&codec)
+      : _codec(std::make_shared<erased_codec_impl<codec_type>>(std::forward<codec_type>(codec))) {}
 
   object_type decode(decode_context &context) const {
     return _codec->decode(context);
@@ -62,8 +61,8 @@ class any_codec_t final {
   template <typename codec_type>
   class erased_codec_impl final : public erased_codec {
    public:
-    explicit erased_codec_impl(codec_type codec)
-      : _codec(std::move(codec)) {}
+    explicit erased_codec_impl(codec_type &&codec) : _codec(std::move(codec)) {}
+    explicit erased_codec_impl(const codec_type &codec) : _codec(codec) {}
 
     object_type decode(decode_context &context) const override {
       return _codec.decode(context);

--- a/include/spotify/json/codec/array.hpp
+++ b/include/spotify/json/codec/array.hpp
@@ -135,8 +135,8 @@ class array_t final {
           typename T::value_type>::value,
       "Inner codec type must be convertible to array container type");
 
-  explicit array_t(codec_type inner_codec)
-      : _inner_codec(std::move(inner_codec)) {}
+  explicit array_t(codec_type &&inner_codec) : _inner_codec(std::move(inner_codec)) {}
+  explicit array_t(const codec_type &inner_codec) : _inner_codec(inner_codec) {}
 
   object_type decode(decode_context &context) const {
     using inserter = detail::container_inserter<T>;

--- a/include/spotify/json/codec/boolean.hpp
+++ b/include/spotify/json/codec/boolean.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Spotify AB
+ * Copyright (c) 2015-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,16 +16,9 @@
 
 #pragma once
 
-#include <cstring>
-
 #include <spotify/json/decode_context.hpp>
 #include <spotify/json/default_codec.hpp>
-#include <spotify/json/detail/decode_helpers.hpp>
 #include <spotify/json/encode_context.hpp>
-
-#if _MSC_VER
-#pragma intrinsic (memcpy)
-#endif
 
 namespace spotify {
 namespace json {
@@ -35,21 +28,8 @@ class boolean_t final {
  public:
   using object_type = bool;
 
-  object_type decode(decode_context &context) const {
-    switch (detail::peek(context)) {
-      case 'f': detail::skip_false(context); return false;
-      case 't': detail::skip_true(context); return true;
-      default: detail::fail(context, "Unexpected input, expected boolean");
-    }
-  }
-
-  void encode(encode_context &context, const object_type value) const {
-    const auto needed = 5 - size_t(value);  // true: 4, false: 5
-    const auto buffer = context.reserve(needed);
-    memcpy(buffer, value ? "true" : "fals", 4);  // 4 byte writes optimize well on x86
-    buffer[needed - 1] = 'e'; // write the missing 'e' in 'false' (or overwrite it in 'true')
-    context.advance(needed);
-  }
+  object_type decode(decode_context &context) const;
+  void encode(encode_context &context, const object_type value) const;
 };
 
 inline boolean_t boolean() {

--- a/include/spotify/json/codec/cast.hpp
+++ b/include/spotify/json/codec/cast.hpp
@@ -41,8 +41,8 @@ class cast_t {
  public:
   using object_type = T;
 
-  explicit cast_t(codec_type inner_codec)
-      : _inner_codec(std::move(inner_codec)) {}
+  explicit cast_t(codec_type &&inner_codec) : _inner_codec(std::move(inner_codec)) {}
+  explicit cast_t(const codec_type &inner_codec) : _inner_codec(inner_codec) {}
 
   object_type decode(decode_context &context) const {
     return _inner_codec.decode(context);

--- a/include/spotify/json/codec/empty_as.hpp
+++ b/include/spotify/json/codec/empty_as.hpp
@@ -41,9 +41,10 @@ class empty_as_t final {
 
   empty_as_t() = default;
 
-  empty_as_t(empty_codec_type empty_codec, inner_codec_type inner_codec)
-      : _empty_codec(std::move(empty_codec)),
-        _inner_codec(std::move(inner_codec)) {}
+  template <typename empty_codec_arg_type, typename inner_codec_arg_type>
+  empty_as_t(empty_codec_arg_type &&empty_codec, inner_codec_arg_type &&inner_codec)
+      : _empty_codec(std::forward<empty_codec_arg_type>(empty_codec)),
+        _inner_codec(std::forward<inner_codec_arg_type>(inner_codec)) {}
 
   object_type decode(decode_context &context) const {
     const auto original_position = context.position;

--- a/include/spotify/json/codec/enumeration.hpp
+++ b/include/spotify/json/codec/enumeration.hpp
@@ -43,8 +43,9 @@ class enumeration_t final {
  public:
   using object_type = outer_type;
 
-  enumeration_t(codec_type inner_codec, mapping_type &&mapping)
-      : _inner_codec(std::move(inner_codec)),
+  template <typename codec_arg_type>
+  enumeration_t(codec_arg_type &&inner_codec, mapping_type &&mapping)
+      : _inner_codec(std::forward<codec_arg_type>(inner_codec)),
         _mapping(std::move(mapping)) {}
 
   object_type decode(decode_context &context) const {

--- a/include/spotify/json/codec/eq.hpp
+++ b/include/spotify/json/codec/eq.hpp
@@ -39,9 +39,10 @@ class eq_t final {
  public:
   using object_type = typename codec_type::object_type;
 
-  eq_t(codec_type inner_codec, object_type value)
-      : _inner_codec(std::move(inner_codec)),
-        _value(std::move(value)) {}
+  template <typename codec_arg_type, typename object_arg_type>
+  eq_t(codec_arg_type &&inner_codec, object_arg_type &&value)
+      : _inner_codec(std::forward<codec_arg_type>(inner_codec)),
+        _value(std::forward<object_arg_type>(value)) {}
 
   object_type decode(decode_context &context) const {
     object_type result = _inner_codec.decode(context);

--- a/include/spotify/json/codec/eq.hpp
+++ b/include/spotify/json/codec/eq.hpp
@@ -18,6 +18,7 @@
 
 #include <spotify/json/decode_context.hpp>
 #include <spotify/json/default_codec.hpp>
+#include <spotify/json/detail/decode_helpers.hpp>
 #include <spotify/json/detail/encode_helpers.hpp>
 
 namespace spotify {

--- a/include/spotify/json/codec/map.hpp
+++ b/include/spotify/json/codec/map.hpp
@@ -49,8 +49,8 @@ class map_t final {
           typename T::mapped_type>::value,
       "Inner codec type must be convertible to map data type");
 
-  explicit map_t(codec_type inner_codec)
-      : _inner_codec(std::move(inner_codec)) {}
+  explicit map_t(codec_type &&inner_codec) : _inner_codec(std::move(inner_codec)) {}
+  explicit map_t(const codec_type &inner_codec) : _inner_codec(inner_codec) {}
 
   object_type decode(decode_context &context) const {
     using value_type = typename object_type::value_type;

--- a/include/spotify/json/codec/number.hpp
+++ b/include/spotify/json/codec/number.hpp
@@ -35,9 +35,11 @@ namespace detail {
 
 float decode_float(decode_context &context);
 double decode_double(decode_context &context);
+void encode_float(encode_context &context, float value);
+void encode_double(encode_context &context, double value);
 
-template <typename T>
-T decode_floating_point(decode_context &context);
+template <typename T> T decode_floating_point(decode_context &context);
+template <typename T> void encode_floating_point(encode_context &context, T value);
 
 template <>
 json_force_inline float decode_floating_point(decode_context &context) {
@@ -49,6 +51,16 @@ json_force_inline double decode_floating_point(decode_context &context) {
   return decode_double(context);
 }
 
+template <>
+json_force_inline void encode_floating_point(encode_context &context, float value) {
+  encode_float(context, value);
+}
+
+template <>
+json_force_inline void encode_floating_point(encode_context &context, double value) {
+  encode_double(context, value);
+}
+
 template <typename T>
 class floating_point_t {
  public:
@@ -58,26 +70,8 @@ class floating_point_t {
     return decode_floating_point<object_type>(context);
   }
 
-  void encode(encode_context &context, const object_type &value) const {
-    // The maximum buffer size required to emit a double in base 10, for decimal
-    // and exponential representations, is 25 bytes; based on the settings used
-    // below for the DoubleToStringConverter. We add another byte for the null
-    // terminator, but it is not actually needed because we don't finalize the
-    // builder.
-    const auto max_required_size = 26;
-    const auto p = reinterpret_cast<char *>(context.reserve(max_required_size));
-
-    // The converter is based on the ECMAScript converter, but will not convert
-    // special values, like Infinity and NaN, since JSON does not support those.
-    using dtoa_converter = double_conversion::DoubleToStringConverter;
-    const dtoa_converter converter(
-        dtoa_converter::UNIQUE_ZERO | dtoa_converter::EMIT_POSITIVE_EXPONENT_SIGN,
-        nullptr, nullptr, 'e', -6, 21, 6, 0);
-
-    using dtoa_builder = double_conversion::StringBuilder;
-    dtoa_builder builder(p, max_required_size);
-    detail::fail_if(context, !converter.ToShortest(value, &builder), "Special values like 'Infinity' or 'NaN' are supported in JSON.");
-    context.advance(builder.position());
+  json_force_inline void encode(encode_context &context, const object_type &value) const {
+    encode_floating_point<object_type>(context, value);
   }
 };
 

--- a/include/spotify/json/codec/object.hpp
+++ b/include/spotify/json/codec/object.hpp
@@ -118,7 +118,8 @@ class object_t final : public codec_detail::object_t_base {
   T construct(std::false_type /*is_default_constructible*/) const {
     // T is not default constructible. Because _construct must be set if T is
     // not default constructible, there is no reason to test it in this case.
-    return (*_construct)();
+    const auto &typed = static_cast<const construct_callable &>(*_construct);
+    return typed();
   }
 
   template <typename codec_type>

--- a/include/spotify/json/codec/smart_ptr.hpp
+++ b/include/spotify/json/codec/smart_ptr.hpp
@@ -57,8 +57,8 @@ class smart_ptr_t final {
  public:
   using object_type = T;
 
-  explicit smart_ptr_t(codec_type inner_codec)
-      : _inner_codec(std::move(inner_codec)) {}
+  explicit smart_ptr_t(codec_type &&inner_codec) : _inner_codec(std::move(inner_codec)) {}
+  explicit smart_ptr_t(const codec_type &inner_codec) : _inner_codec(inner_codec) {}
 
   object_type decode(decode_context &context) const {
     return codec::make_smart_ptr_t<object_type>::make(_inner_codec.decode(context));

--- a/include/spotify/json/codec/transform.hpp
+++ b/include/spotify/json/codec/transform.hpp
@@ -118,13 +118,14 @@ class transform_t final {
  public:
   using object_type = typename std::result_of<decode_transform(typename codec_type::object_type)>::type;
 
+  template <typename codec_arg_type, typename encode_transform_arg, typename decode_transform_arg>
   transform_t(
-      codec_type inner_codec,
-      encode_transform encode,
-      decode_transform decode)
-      : _inner_codec(std::move(inner_codec)),
-        _encode_transform(std::move(encode)),
-        _decode_transform(std::move(decode)) {}
+      codec_arg_type &&inner_codec,
+      encode_transform_arg &&encode,
+      decode_transform_arg &&decode)
+      : _inner_codec(std::forward<codec_arg_type>(inner_codec)),
+        _encode_transform(std::forward<encode_transform_arg>(encode)),
+        _decode_transform(std::forward<decode_transform_arg>(decode)) {}
 
   object_type decode(decode_context &context) const {
     const auto offset_before_decoding = context.offset();

--- a/include/spotify/json/decode_context.hpp
+++ b/include/spotify/json/decode_context.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Spotify AB
+ * Copyright (c) 2014-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cstddef>
-
 #include <spotify/json/decode_exception.hpp>
 #include <spotify/json/detail/cpuid.hpp>
 #include <spotify/json/detail/macros.hpp>
@@ -31,17 +30,8 @@ namespace json {
  * has failed.
  */
 struct decode_context final {
-  decode_context(const char *begin, const char *end)
-      : has_sse42(detail::cpuid().has_sse42()),
-        position(begin),
-        begin(begin),
-        end(end) {}
-
-  decode_context(const char *data, size_t size)
-      : has_sse42(detail::cpuid().has_sse42()),
-        position(data),
-        begin(data),
-        end(data + size) {}
+  decode_context(const char *begin, const char *end);
+  decode_context(const char *data, size_t size);
 
   json_force_inline size_t offset() const {
     return (position - begin);

--- a/include/spotify/json/detail/bitset.hpp
+++ b/include/spotify/json/detail/bitset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Spotify AB
+ * Copyright (c) 2016-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <memory>
 #include <vector>
@@ -27,35 +26,38 @@ namespace spotify {
 namespace json {
 namespace detail {
 
-template <std::size_t inline_size>
-struct bitset {
-  bitset(const std::size_t size) {
-    if (json_likely(size <= inline_size)) {
-      _array.fill(0x00);
-    } else {
-      _vector.reset(new std::vector<uint8_t>((size + 7) / 8));
-    }
-  }
+struct bitset_base {
+  ~bitset_base();
 
   json_force_inline uint8_t test_and_set(const std::size_t index) {
     const auto byte = (index / 8);
     const auto bidx = (index & 7);
     const auto mask = (1 << bidx);
-    if (json_likely(!_vector)) {
-      const auto byte_before = _array[byte];
-      _array[byte] = (byte_before | mask);
-      return (byte_before & mask) >> bidx;
-    } else {
-      const auto byte_before = (*_vector)[byte];
-      (*_vector)[byte] = (byte_before | mask);
-      return (byte_before & mask) >> bidx;
+    const auto byte_before = _base[byte];
+    _base[byte] = (byte_before | mask);
+    return (byte_before & mask) >> bidx;
+  }
+
+ protected:
+  bitset_base(const std::size_t size, uint8_t *inline_base);
+
+ private:
+  std::unique_ptr<std::vector<uint8_t>> _vector;
+  uint8_t *_base;
+};
+
+template <std::size_t inline_size>
+struct bitset final : public bitset_base {
+  bitset(const std::size_t size)
+      : bitset_base(size, size <= inline_size ? _array : nullptr) {
+    if (json_likely(size <= inline_size)) {
+      memset(_array, 0, sizeof(_array));
     }
   }
 
  private:
   static constexpr auto _num_inline_bytes = ((inline_size + 7) / 8);
-  std::unique_ptr<std::vector<uint8_t>> _vector;
-  std::array<uint8_t, _num_inline_bytes> _array;
+  uint8_t _array[_num_inline_bytes];
 };
 
 }  // namespace detail

--- a/include/spotify/json/detail/decode_helpers.hpp
+++ b/include/spotify/json/detail/decode_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Spotify AB
+ * Copyright (c) 2014-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,19 +35,12 @@ namespace spotify {
 namespace json {
 namespace detail {
 
-template <typename string_type>
-json_never_inline json_noreturn void fail(
-    const decode_context &context,
-    const string_type &error,
-    const ptrdiff_t d = 0) {
-  throw decode_exception(error, context.offset(d));
-}
+json_noreturn void fail(const decode_context &context, const char *error, ptrdiff_t d = 0);
 
-template <typename string_type, typename condition_type>
 json_force_inline void fail_if(
     const decode_context &context,
-    const condition_type condition,
-    const string_type &error,
+    const bool condition,
+    const char *error,
     const ptrdiff_t d = 0) {
   if (json_unlikely(condition)) {
     fail(context, error, d);

--- a/include/spotify/json/detail/encode_helpers.hpp
+++ b/include/spotify/json/detail/encode_helpers.hpp
@@ -24,18 +24,12 @@ namespace spotify {
 namespace json {
 namespace detail {
 
-template <typename string_type>
-json_never_inline json_noreturn void fail(
-    const encode_context & /*context*/,
-    const string_type &error) {
-  throw encode_exception(error);
-}
+json_noreturn void fail(const encode_context & /*context*/, const char *error);
 
-template <typename string_type, typename condition_type>
 json_force_inline void fail_if(
     const encode_context &context,
-    const condition_type condition,
-    const string_type &error) {
+    const bool condition,
+    const char *error) {
   if (json_unlikely(condition)) {
     fail(context, error);
   }

--- a/include/spotify/json/detail/escape.hpp
+++ b/include/spotify/json/detail/escape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Spotify AB
+ * Copyright (c) 2014-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,23 +17,10 @@
 #pragma once
 
 #include <spotify/json/encode_context.hpp>
-#include <spotify/json/detail/macros.hpp>
 
 namespace spotify {
 namespace json {
 namespace detail {
-
-void write_escaped_scalar(
-    encode_context &context,
-    const char *begin,
-    const char *end);
-
-#if defined(json_arch_x86_sse42)
-void write_escaped_sse42(
-    encode_context &context,
-    const char *begin,
-    const char *end);
-#endif  // defined(json_arch_x86_sse42)
 
 /**
  * \brief Escape a string for use in a JSON string as per RFC 4627.
@@ -43,17 +30,7 @@ void write_escaped_sse42(
  *
  * See: http://www.ietf.org/rfc/rfc4627.txt (Section 2.5)
  */
-json_force_inline void write_escaped(
-    encode_context &context,
-    const char *begin,
-    const char *end) {
-#if defined(json_arch_x86_sse42)
-  if (json_likely(context.has_sse42)) {
-    return write_escaped_sse42(context, begin, end);
-  }
-#endif  // defined(json_arch_x86_sse42)
-  write_escaped_scalar(context, begin, end);
-}
+void write_escaped(encode_context &context, const char *begin, const char *end);
 
 }  // namespace detail
 }  // namespace json

--- a/include/spotify/json/detail/field_registry.hpp
+++ b/include/spotify/json/detail/field_registry.hpp
@@ -16,29 +16,47 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include <spotify/json/decode_context.hpp>
+#include <spotify/json/encode_context.hpp>
+
 namespace spotify {
 namespace json {
 namespace detail {
 
-// This is a non-templated base class for field types to reduce binary size by avoiding template
-// instantiation explosion of shared_ptr<field_type> in object_t.
-//
-// It needs a virtual destructor so the shared_ptr<detail::field_base> deleter does the right thing.
-struct field_base {
-  virtual ~field_base() = default;
+// This is a non-templated base class for field types to reduce binary size by
+// avoiding template instantiation explosion of shared_ptr<field_type> in
+// object_t. It needs a virtual destructor so the shared_ptr<detail::field>
+// deleter does the right thing.
+struct field {
+  field(bool required, size_t required_field_idx)
+      : _data(required ? required_field_idx : json_size_t_max) {}
+  virtual ~field() = default;
+
+  virtual void decode(decode_context &context, void *object) const = 0;
+  virtual void encode(
+      encode_context &context,
+      const std::string &escaped_key,
+      const void *object) const = 0;
+
+  json_force_inline bool is_required() const { return (_data != json_size_t_max); }
+  json_force_inline size_t required_field_idx() const { return _data; }
+
+ private:
+  size_t _data;
 };
 
 // Non-templated class to reduce code bloat.
 class field_registry final {
  public:
-  using field_vec = std::vector<std::pair<std::string, std::shared_ptr<const field_base>>>;
-  using field_map = std::unordered_map<std::string, std::shared_ptr<const field_base>>;
+  using field_vec = std::vector<std::pair<std::string, std::shared_ptr<const field>>>;
+  using field_map = std::unordered_map<std::string, std::shared_ptr<const field>>;
   using const_iterator = typename field_vec::const_iterator;
 
   field_registry();
@@ -50,8 +68,8 @@ class field_registry final {
   inline const_iterator begin() const noexcept { return _field_list.begin(); }
   inline const_iterator end() const noexcept { return _field_list.end(); }
 
-  void save(const std::string &name, bool required, const std::shared_ptr<field_base> &f);
-  const field_base *find(const std::string &name) const noexcept;
+  void save(const std::string &name, bool required, const std::shared_ptr<field> &f);
+  const field *find(const std::string &name) const noexcept;
   size_t num_required_fields() const noexcept { return _num_required_fields; }
 
  private:

--- a/include/spotify/json/encode_context.hpp
+++ b/include/spotify/json/encode_context.hpp
@@ -16,15 +16,11 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <limits>
 #include <memory>
-
-#include <spotify/json/detail/cpuid.hpp>
 #include <spotify/json/detail/macros.hpp>
 
 namespace spotify {
@@ -35,28 +31,15 @@ namespace json {
  * codecs. It keeps a buffer of data that can be expanded and written to.
  */
 struct encode_context final {
-  encode_context(const std::size_t capacity = 4096)
-      : has_sse42(detail::cpuid().has_sse42()),
-        _buf(static_cast<char *>(capacity ? std::malloc(capacity) : nullptr)),
-        _ptr(_buf),
-        _end(_buf + capacity),
-        _capacity(capacity) {
-    if (json_unlikely(!_buf && _capacity > 0)) {
-      throw std::bad_alloc();
-    }
-  }
-
-  ~encode_context() {
-    std::free(_buf);
-  }
+  encode_context(const std::size_t capacity = 4096);
+  ~encode_context();
 
   json_force_inline char *reserve(const std::size_t reserved_bytes) {
     const auto remaining_bytes = static_cast<std::size_t>(_end - _ptr);  // _end is always >= _ptr
     if (json_likely(remaining_bytes >= reserved_bytes)) {
       return _ptr;
     } else {
-      grow_buffer(reserved_bytes);
-      return _ptr;
+      return grow_buffer(reserved_bytes);
     }
   }
 
@@ -102,48 +85,12 @@ struct encode_context final {
     return (_ptr == _buf);
   }
 
-  std::unique_ptr<void, decltype(std::free) *> steal_data() {
-    const auto data = _buf;
-    _buf = nullptr;
-    _ptr = nullptr;
-    _end = nullptr;
-    _capacity = 0;
-    return std::unique_ptr<void, decltype(std::free) *>(data, &std::free);
-  }
+  std::unique_ptr<void, decltype(std::free) *> steal_data();
 
   const bool has_sse42;
 
  private:
-  json_never_inline void grow_buffer(const std::size_t num_bytes) {
-    const auto old_size = size();
-    const auto new_size = std::size_t(old_size + num_bytes);
-    if (json_unlikely(new_size < old_size)) {
-      // If we overflow the size integer, it means that we need more memory than
-      // we can possibly provide, so we should throw an allocation exception.
-      throw std::bad_alloc();
-    }
-
-    auto new_capacity = std::size_t(_capacity * 2);
-    if (json_unlikely(new_capacity <= _capacity && _capacity)) {
-      // If we overflow the capacity integer, set the new capacity to the max
-      // value of the size type, so that we can handle the case of having say
-      // 3 GB of memory allocated, growing to 4 GB instead of failing to grow.
-      new_capacity = std::numeric_limits<std::size_t>::max();
-    }
-
-    // Regardless of what capacity we think we want, we need to ensure that it
-    // is at least as large as the reserved size. We avoid doing any arithmetics
-    // here to not have to check for overflow yet again.
-    const auto actual_capacity = std::max(new_size, new_capacity);
-    _buf = static_cast<char *>(std::realloc(_buf, actual_capacity));
-    if (json_unlikely(!_buf)) {
-      throw std::bad_alloc();
-    }
-
-    _ptr = _buf + old_size;
-    _end = _buf + actual_capacity;
-    _capacity = actual_capacity;
-  }
+  char * grow_buffer(const std::size_t num_bytes);
 
   char *_buf;
   char *_ptr;

--- a/include/spotify/json/encoded_value.hpp
+++ b/include/spotify/json/encoded_value.hpp
@@ -36,11 +36,7 @@ struct encoded_value_base {
   struct unsafe_unchecked {};
 
  protected:
-  static void validate_json(const char *data, std::size_t size) {
-    decode_context context(data, size);
-    detail::skip_value(context);  // validate provided JSON string
-    detail::fail_if(context, context.position != context.end, "Unexpected trailing input");
-  }
+  void validate_json(const char *data, std::size_t size);
 };
 
 }  // namespace detail

--- a/src/codec/any_value.cpp
+++ b/src/codec/any_value.cpp
@@ -14,44 +14,25 @@
  * the License.
  */
 
-#pragma once
+#include <spotify/json/codec/any_value.hpp>
 
-#include <spotify/json/decode_context.hpp>
-#include <spotify/json/default_codec.hpp>
-#include <spotify/json/encode_context.hpp>
-#include <spotify/json/encoded_value.hpp>
+#include <spotify/json/detail/skip_value.hpp>
 
 namespace spotify {
 namespace json {
 namespace codec {
 
-class any_value_t final {
- public:
-  using object_type = encoded_value_ref;
+any_value_t::object_type any_value_t::decode(decode_context &context) const {
+  const auto begin = context.position;
+  detail::skip_value(context);
+  const auto size = context.position - begin;
+  return object_type(begin, size, object_type::unsafe_unchecked());
+}
 
-  object_type decode(decode_context &context) const;
-  void encode(encode_context &context, const object_type &value) const;
-};
-
-inline any_value_t any_value() {
-  return any_value_t();
+void any_value_t::encode(encode_context &context, const object_type &value) const {
+  context.append(value.data(), value.size());
 }
 
 }  // namespace codec
-
-template<>
-struct default_codec_t<encoded_value> {
-  static codec::any_value_t codec() {
-    return codec::any_value();
-  }
-};
-
-template<>
-struct default_codec_t<encoded_value_ref> {
-  static codec::any_value_t codec() {
-    return codec::any_value();
-  }
-};
-
 }  // namespace json
 }  // namespace spotify

--- a/src/codec/boolean.cpp
+++ b/src/codec/boolean.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/codec/boolean.hpp>
+
+#include <cstring>
+#include <spotify/json/decode_exception.hpp>
+#include <spotify/json/detail/decode_helpers.hpp>
+#include <spotify/json/detail/skip_chars.hpp>
+
+#if _MSC_VER
+#pragma intrinsic (memcpy)
+#endif
+
+namespace spotify {
+namespace json {
+namespace codec {
+
+boolean_t::object_type boolean_t::decode(decode_context &context) const {
+  switch (detail::peek(context)) {
+    case 'f': detail::skip_false(context); return false;
+    case 't': detail::skip_true(context); return true;
+    default: detail::fail(context, "Unexpected input, expected boolean");
+  }
+}
+
+void boolean_t::encode(encode_context &context, const object_type value) const {
+  const auto needed = 5 - size_t(value);  // true: 4, false: 5
+  const auto buffer = context.reserve(needed);
+  memcpy(buffer, value ? "true" : "fals", 4);  // 4 byte writes optimize well on x86
+  buffer[needed - 1] = 'e'; // write the missing 'e' in 'false' (or overwrite it in 'true')
+  context.advance(needed);
+}
+
+}  // namespace codec
+}  // namespace json
+}  // namespace spotify

--- a/src/codec/number.cpp
+++ b/src/codec/number.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/codec/number.hpp>
+
+#include <limits>
+#include <double-conversion/double-conversion.h>
+
+namespace spotify {
+namespace json {
+namespace detail {
+
+float decode_float(decode_context &context) {
+  using atod_converter = double_conversion::StringToDoubleConverter;
+  static const atod_converter converter(
+      atod_converter::ALLOW_TRAILING_JUNK,
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
+      nullptr,
+      nullptr);
+
+  int bytes_read = 0;
+  auto remaining = static_cast<int>(context.end - context.position);
+  auto result = converter.StringToFloat(context.position, remaining, &bytes_read);
+  fail_if(context, std::isnan(result), "Invalid floating point number");
+  skip_unchecked_n(context, bytes_read);
+  return result;
+}
+
+double decode_double(decode_context &context) {
+  using atod_converter = double_conversion::StringToDoubleConverter;
+  static const atod_converter converter(
+      atod_converter::ALLOW_TRAILING_JUNK,
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
+      nullptr,
+      nullptr);
+
+  int bytes_read = 0;
+  auto remaining = static_cast<int>(context.end - context.position);
+  auto result = converter.StringToDouble(context.position, remaining, &bytes_read);
+  fail_if(context, std::isnan(result), "Invalid floating point number");
+  skip_unchecked_n(context, bytes_read);
+  return result;
+}
+
+}  // namespace detail
+}  // namespace json
+}  // namespace spotify

--- a/src/codec/number.cpp
+++ b/src/codec/number.cpp
@@ -57,6 +57,50 @@ double decode_double(decode_context &context) {
   return result;
 }
 
+void encode_float(encode_context &context, float value) {
+  // The maximum buffer size required to emit a double in base 10, for decimal
+  // and exponential representations, is 25 bytes; based on the settings used
+  // below for the DoubleToStringConverter. We add another byte for the null
+  // terminator, but it is not actually needed because we don't finalize the
+  // builder.
+  const auto max_required_size = 26;
+  const auto p = reinterpret_cast<char *>(context.reserve(max_required_size));
+
+  // The converter is based on the ECMAScript converter, but will not convert
+  // special values, like Infinity and NaN, since JSON does not support those.
+  using dtoa_converter = double_conversion::DoubleToStringConverter;
+  const dtoa_converter converter(
+      dtoa_converter::UNIQUE_ZERO | dtoa_converter::EMIT_POSITIVE_EXPONENT_SIGN,
+      nullptr, nullptr, 'e', -6, 21, 6, 0);
+
+  using dtoa_builder = double_conversion::StringBuilder;
+  dtoa_builder builder(p, max_required_size);
+  detail::fail_if(context, !converter.ToShortest(value, &builder), "Special values like 'Infinity' or 'NaN' are supported in JSON.");
+  context.advance(builder.position());
+}
+
+void encode_double(encode_context &context, double value) {
+  // The maximum buffer size required to emit a double in base 10, for decimal
+  // and exponential representations, is 25 bytes; based on the settings used
+  // below for the DoubleToStringConverter. We add another byte for the null
+  // terminator, but it is not actually needed because we don't finalize the
+  // builder.
+  const auto max_required_size = 26;
+  const auto p = reinterpret_cast<char *>(context.reserve(max_required_size));
+
+  // The converter is based on the ECMAScript converter, but will not convert
+  // special values, like Infinity and NaN, since JSON does not support those.
+  using dtoa_converter = double_conversion::DoubleToStringConverter;
+  const dtoa_converter converter(
+      dtoa_converter::UNIQUE_ZERO | dtoa_converter::EMIT_POSITIVE_EXPONENT_SIGN,
+      nullptr, nullptr, 'e', -6, 21, 6, 0);
+
+  using dtoa_builder = double_conversion::StringBuilder;
+  dtoa_builder builder(p, max_required_size);
+  detail::fail_if(context, !converter.ToShortest(value, &builder), "Special values like 'Infinity' or 'NaN' are supported in JSON.");
+  context.advance(builder.position());
+}
+
 }  // namespace detail
 }  // namespace json
 }  // namespace spotify

--- a/src/codec/object.cpp
+++ b/src/codec/object.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/codec/object.hpp>
+
+namespace spotify {
+namespace json {
+namespace codec {
+namespace codec_detail {
+
+object_t_base::object_t_base() = default;
+object_t_base::object_t_base(object_t_base &&other) = default;
+object_t_base::object_t_base(const object_t_base &other) = default;
+object_t_base::~object_t_base() = default;
+
+void object_t_base::decode(decode_context &context, void *value) const {
+  uint_fast32_t uniq_seen_required = 0;
+  detail::bitset<64> seen_required(_fields.num_required_fields());
+
+  detail::decode_object<string_t>(context, [&](const std::string &key) {
+    const auto *field = _fields.find(key);
+    if (json_unlikely(!field)) {
+      return detail::skip_value(context);
+    }
+
+    field->decode(context, value);
+    if (field->is_required()) {
+      const auto seen = seen_required.test_and_set(field->required_field_idx());
+      uniq_seen_required += (1 - seen);  // 'seen' is 1 when the field is a duplicate; 0 otherwise
+    }
+  });
+
+  const auto is_missing_req_fields = (uniq_seen_required != _fields.num_required_fields());
+  detail::fail_if(context, is_missing_req_fields, "Missing required field(s)");
+}
+
+void object_t_base::encode(encode_context &context, const void *value) const {
+  context.append('{');
+  for (const auto &kv : _fields) {
+    const auto &field = *kv.second.get();
+    field.encode(context, kv.first, value);
+  }
+  context.append_or_replace(',', '}');
+}
+
+}  // namespace codec_detail
+}  // namespace codec
+}  // namespace json
+}  // namespace spotify

--- a/src/codec/object.cpp
+++ b/src/codec/object.cpp
@@ -23,8 +23,8 @@ namespace codec_detail {
 
 object_t_base::object_t_base() = default;
 object_t_base::object_t_base(construct_untyped *construct) : _construct(construct) {}
-object_t_base::object_t_base(object_t_base &&other) = default;
-object_t_base::object_t_base(const object_t_base &other) = default;
+object_t_base::object_t_base(object_t_base &&) = default;
+object_t_base::object_t_base(const object_t_base &) = default;
 object_t_base::~object_t_base() = default;
 
 void object_t_base::decode(decode_context &context, void *value) const {

--- a/src/codec/object.cpp
+++ b/src/codec/object.cpp
@@ -22,6 +22,7 @@ namespace codec {
 namespace codec_detail {
 
 object_t_base::object_t_base() = default;
+object_t_base::object_t_base(construct_untyped *construct) : _construct(construct) {}
 object_t_base::object_t_base(object_t_base &&other) = default;
 object_t_base::object_t_base(const object_t_base &other) = default;
 object_t_base::~object_t_base() = default;

--- a/src/codec/string.cpp
+++ b/src/codec/string.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2015-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/codec/string.hpp>
+
+#include <spotify/json/decode_exception.hpp>
+#include <spotify/json/detail/decode_helpers.hpp>
+#include <spotify/json/detail/escape.hpp>
+#include <spotify/json/detail/macros.hpp>
+#include <spotify/json/detail/skip_chars.hpp>
+
+namespace spotify {
+namespace json {
+namespace codec {
+namespace {
+
+bool is_high_surrogate(unsigned p) {
+  return (p & 0xFC00) == 0xD800;
+}
+
+bool is_low_surrogate(unsigned p) {
+  return (p & 0xFC00) == 0xDC00;
+}
+
+uint32_t codepoint_from_surrogate_pair(uint32_t high, uint32_t low) {
+  return (((high & 0x03FF) << 10) | (low & 0x03FF)) + 0x10000;
+}
+
+uint8_t decode_hex_nibble(decode_context &context, const char c) {
+  if (c >= '0' && c <= '9') { return c - '0'; }
+  if (c >= 'a' && c <= 'f') { return c - 'a' + 0xA; }
+  if (c >= 'A' && c <= 'F') { return c - 'A' + 0xA; }
+  detail::fail(context, "\\u must be followed by 4 hex digits");
+}
+
+unsigned decode_hex_number(decode_context &context) {
+  detail::require_bytes<4>(context, "\\u must be followed by 4 hex digits");
+  const auto a = decode_hex_nibble(context, *(context.position++));
+  const auto b = decode_hex_nibble(context, *(context.position++));
+  const auto c = decode_hex_nibble(context, *(context.position++));
+  const auto d = decode_hex_nibble(context, *(context.position++));
+  return unsigned((a << 12) | (b << 8) | (c << 4) | d);
+}
+
+void encode_utf8_4(std::string &out, uint32_t p) {
+  const char c0 = 0xF0 | ((p >> 18) & 0x07);
+  const char c1 = 0x80 | ((p >> 12) & 0x3F);
+  const char c2 = 0x80 | ((p >>  6) & 0x3F);
+  const char c3 = 0x80 | ((p >>  0) & 0x3F);
+  const char cc[] = { c0, c1, c2, c3 };
+  out.append(&cc[0], 4);
+}
+
+void encode_utf8_3(std::string &out, unsigned p) {
+  const char c0 = 0xE0 | ((p >> 12) & 0x0F);
+  const char c1 = 0x80 | ((p >>  6) & 0x3F);
+  const char c2 = 0x80 | ((p >>  0) & 0x3F);
+  const char cc[] = { c0, c1, c2 };
+  out.append(&cc[0], 3);
+}
+
+void encode_utf8_2(std::string &out, unsigned p) {
+  const char c0 = 0xC0 | ((p >> 6) & 0x1F);
+  const char c1 = 0x80 | ((p >> 0) & 0x3F);
+  const char cc[] = { c0, c1 };
+  out.append(&cc[0], 2);
+}
+
+void encode_utf8_1(std::string &out, unsigned p) {
+  const char c0 = (p & 0x7F);
+  out.push_back(c0);
+}
+
+void encode_utf8(std::string &out, unsigned p) {
+  if (json_likely(p <= 0x7F)) {
+    encode_utf8_1(out, p);
+  } else if (json_likely(p <= 0x07FF)) {
+    encode_utf8_2(out, p);
+  } else {
+    encode_utf8_3(out, p);
+  }
+}
+
+bool handle_surrogate_pair(decode_context &context, std::string &out, unsigned p) {
+  if (json_unlikely(is_high_surrogate(p))) {
+    // Parse low surrogate
+    if (detail::peek_2(context, '\\', 'u')) {
+      detail::skip_unchecked_n(context, 2);
+      const auto n = decode_hex_number(context);
+      if (json_likely(is_low_surrogate(n))) {
+        // Any Unicode codepoint encoded by a surrogate pair is 4 bytes in UTF-8
+        encode_utf8_4(out, codepoint_from_surrogate_pair(p, n));
+        return true;
+      } else {
+        // Rewind context to before the escape sequence
+        context.position -= 6;
+      }
+    }
+  }
+
+  return false;
+}
+
+void decode_unicode_escape(decode_context &context, std::string &out) {
+  const auto p = decode_hex_number(context);
+  if (json_likely(!handle_surrogate_pair(context, out, p))) {
+    encode_utf8(out, p);
+  }
+}
+
+void decode_escape(decode_context &context, std::string &out) {
+  const auto escape_character = detail::next(context, "Unterminated string");
+  switch (escape_character) {
+    case '"':  out.push_back('"');  break;
+    case '/':  out.push_back('/');  break;
+    case 'b':  out.push_back('\b'); break;
+    case 'f':  out.push_back('\f'); break;
+    case 'n':  out.push_back('\n'); break;
+    case 'r':  out.push_back('\r'); break;
+    case 't':  out.push_back('\t'); break;
+    case '\\': out.push_back('\\'); break;
+    case 'u': decode_unicode_escape(context, out); break;
+    default: detail::fail(context, "Invalid escape character", -1);
+  }
+}
+
+string_t::object_type decode_escaped_string(decode_context &context, const char *begin) {
+  std::string unescaped(begin, context.position - 1);
+  decode_escape(context, unescaped);
+
+  while (json_likely(context.remaining())) {
+    const auto begin_simple = context.position;
+    detail::skip_any_simple_characters(context);
+    unescaped.append(begin_simple, context.position);
+
+    switch (detail::next(context, "Unterminated string")) {
+      case '"': return unescaped;
+      case '\\': decode_escape(context, unescaped); break;
+      default: json_unreachable();
+    }
+  }
+
+  detail::fail(context, "Unterminated string");
+}
+
+string_t::object_type decode_string(decode_context &context) {
+  const auto begin_simple = context.position;
+  detail::skip_any_simple_characters(context);
+
+  switch (detail::next(context, "Unterminated string")) {
+    case '"': return std::string(begin_simple, context.position - 1);
+    case '\\': return decode_escaped_string(context, begin_simple);
+    default: json_unreachable();
+  }
+}
+
+}  // namespace
+
+string_t::object_type string_t::decode(decode_context &context) const {
+  detail::skip_1(context, '"');
+  return decode_string(context);
+}
+
+void string_t::encode(encode_context &context, const object_type value) const {
+  context.append('"');
+
+  // Write the strings in 1024 byte chunks, so that we do not have to reserve a
+  // potentially very large buffer for the escaped string. It is possible that
+  // the chunking will happen in the middle of a UTF-8 multi-byte character, but
+  // that is ok since write_escaped will not escape characters with the high bit
+  // set, so the combined escaped string contains the correct UTF-8 characters
+  // in the end.
+  auto chunk_begin = value.data();
+  const auto string_end = chunk_begin + value.size();
+
+  while (chunk_begin != string_end) {
+    const auto chunk_end = std::min(chunk_begin + 1024, string_end);
+    detail::write_escaped(context, chunk_begin, chunk_end);
+    chunk_begin = chunk_end;
+  }
+
+  context.append('"');
+}
+
+}  // namespace codec
+}  // namespace json
+}  // namespace spotify

--- a/src/decode_context.cpp
+++ b/src/decode_context.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/decode_context.hpp>
+
+namespace spotify {
+namespace json {
+
+decode_context::decode_context(const char *begin, const char *end)
+    : has_sse42(detail::cpuid().has_sse42()),
+      position(begin),
+      begin(begin),
+      end(end) {}
+
+decode_context::decode_context(const char *data, size_t size)
+    : has_sse42(detail::cpuid().has_sse42()),
+      position(data),
+      begin(data),
+      end(data + size) {}
+
+}  // namespace json
+}  // namespace spotify

--- a/src/decode_exception.cpp
+++ b/src/decode_exception.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Spotify AB
+ * Copyright (c) 2015-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,33 +14,16 @@
  * the License.
  */
 
-#pragma once
-
-#include <stdexcept>
-#include <string>
-#include <utility>
-
-#include <spotify/json/detail/macros.hpp>
+#include <spotify/json/decode_exception.hpp>
 
 namespace spotify {
 namespace json {
 
-/**
- * decode_exception objects are thrown when decoding fails, for example if the
- * JSON is invalid, or if the JSON doesn't conform to the specified schema.
- */
-class decode_exception final : public std::runtime_error {
- public:
-  explicit decode_exception(const char *what, size_t offset = 0);
-  decode_exception(decode_exception &&exception, size_t offset);
+decode_exception::decode_exception(const char *what, size_t offset)
+    : runtime_error(what), _offset(offset) {}
 
-  size_t offset() const {
-    return _offset;
-  }
-
- private:
-  size_t _offset;
-};
+decode_exception::decode_exception(decode_exception &&exception, size_t offset)
+    : runtime_error(std::move(exception)), _offset(offset) {}
 
 }  // namespace json
 }  // namespace spotify

--- a/src/detail/bitset.cpp
+++ b/src/detail/bitset.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/detail/bitset.hpp>
+
+namespace spotify {
+namespace json {
+namespace detail {
+
+bitset_base::~bitset_base() = default;
+
+bitset_base::bitset_base(const std::size_t size, uint8_t *inline_base) {
+  if (inline_base) {
+    _base = inline_base;
+  } else {
+    _vector.reset(new std::vector<uint8_t>((size + 7) / 8));
+    _base = _vector->data();
+  }
+}
+
+}  // namespace detail
+}  // namespace json
+}  // namespace spotify

--- a/src/detail/decode_helpers.cpp
+++ b/src/detail/decode_helpers.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/detail/decode_helpers.hpp>
+
+namespace spotify {
+namespace json {
+namespace detail {
+
+json_noreturn void fail(const decode_context &context, const char *error, ptrdiff_t d ) {
+  throw decode_exception(error, context.offset(d));
+}
+
+}  // namespace detail
+}  // namespace json
+}  // namespace spotify

--- a/src/detail/encode_helpers.cpp
+++ b/src/detail/encode_helpers.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/detail/encode_helpers.hpp>
+
+namespace spotify {
+namespace json {
+namespace detail {
+
+json_noreturn void fail(const encode_context &, const char *error) {
+  throw encode_exception(error);
+}
+
+}  // namespace detail
+}  // namespace json
+}  // namespace spotify

--- a/src/detail/field_registry.cpp
+++ b/src/detail/field_registry.cpp
@@ -23,12 +23,14 @@ namespace spotify {
 namespace json {
 namespace detail {
 namespace {
+
 std::string escape_key(const std::string &key) {
   encode_context context;
   codec::string().encode(context, key);
   context.append(':');
   return std::string(context.data(), context.size());
 }
+
 } // namespace
 
 field_registry::field_registry() = default;
@@ -37,7 +39,7 @@ field_registry::field_registry(const field_registry &) = default;
 field_registry::field_registry(field_registry &&) = default;
 
 void field_registry::save(const std::string &name, bool required,
-                          const std::shared_ptr<field_base> &f) {
+                          const std::shared_ptr<field> &f) {
   const auto was_saved =
       _fields.insert(typename field_map::value_type(name, f)).second;
   if (was_saved) {
@@ -46,7 +48,7 @@ void field_registry::save(const std::string &name, bool required,
   }
 }
 
-const field_base *field_registry::find(const std::string &name) const noexcept {
+const field *field_registry::find(const std::string &name) const noexcept {
   const auto field_it = _fields.find(name);
   if (json_likely(field_it != _fields.end())) {
     return (*field_it).second.get();

--- a/src/detail/skip_value.cpp
+++ b/src/detail/skip_value.cpp
@@ -126,7 +126,7 @@ void skip_simple_value(decode_context &context) {
     case 'f': skip_false(context); break;
     case 't': skip_true(context); break;
     case 'n': skip_null(context); break;
-    default: fail(context, std::string("Encountered token '") + peek(context) + "'");
+    default: fail(context, (std::string("Encountered token '") + peek(context) + "'").c_str());
   }
 }
 

--- a/src/encode_context.cpp
+++ b/src/encode_context.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <spotify/json/encode_context.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <spotify/json/detail/cpuid.hpp>
+
+namespace spotify {
+namespace json {
+
+encode_context::encode_context(const std::size_t capacity)
+    : has_sse42(detail::cpuid().has_sse42()),
+      _buf(static_cast<char *>(capacity ? std::malloc(capacity) : nullptr)),
+      _ptr(_buf),
+      _end(_buf + capacity),
+      _capacity(capacity) {
+  if (json_unlikely(!_buf && _capacity > 0)) {
+    throw std::bad_alloc();
+  }
+}
+
+encode_context::~encode_context() {
+  std::free(_buf);
+}
+
+std::unique_ptr<void, decltype(std::free) *> encode_context::steal_data() {
+  const auto data = _buf;
+  _buf = nullptr;
+  _ptr = nullptr;
+  _end = nullptr;
+  _capacity = 0;
+  return std::unique_ptr<void, decltype(std::free) *>(data, &std::free);
+}
+
+char *encode_context::grow_buffer(const std::size_t num_bytes) {
+  const auto old_size = size();
+  const auto new_size = std::size_t(old_size + num_bytes);
+  if (json_unlikely(new_size < old_size)) {
+    // If we overflow the size integer, it means that we need more memory than
+    // we can possibly provide, so we should throw an allocation exception.
+    throw std::bad_alloc();
+  }
+
+  auto new_capacity = std::size_t(_capacity * 2);
+  if (json_unlikely(new_capacity <= _capacity && _capacity)) {
+    // If we overflow the capacity integer, set the new capacity to the max
+    // value of the size type, so that we can handle the case of having say
+    // 3 GB of memory allocated, growing to 4 GB instead of failing to grow.
+    new_capacity = std::numeric_limits<std::size_t>::max();
+  }
+
+  // Regardless of what capacity we think we want, we need to ensure that it
+  // is at least as large as the reserved size. We avoid doing any arithmetics
+  // here to not have to check for overflow yet again.
+  const auto actual_capacity = std::max(new_size, new_capacity);
+  _buf = static_cast<char *>(std::realloc(_buf, actual_capacity));
+  if (json_unlikely(!_buf)) {
+    throw std::bad_alloc();
+  }
+
+  _ptr = _buf + old_size;
+  _end = _buf + actual_capacity;
+  _capacity = actual_capacity;
+
+  return _ptr;
+}
+
+}  // namespace json
+}  // namespace spotify

--- a/src/encode_exception.cpp
+++ b/src/encode_exception.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Spotify AB
+ * Copyright (c) 2016-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,24 +14,12 @@
  * the License.
  */
 
-#pragma once
-
-#include <stdexcept>
-#include <string>
-
-#include <spotify/json/detail/macros.hpp>
+#include <spotify/json/encode_exception.hpp>
 
 namespace spotify {
 namespace json {
 
-/**
- * encode_exception objects are thrown when encoding fails, for example when
- * trying to encode a null smart pointer or a NaN floating point number.
- */
-class encode_exception final : public std::runtime_error {
- public:
-  explicit json_never_inline encode_exception(const char *what);
-};
+encode_exception::encode_exception(const char *what) : runtime_error(what) {}
 
 }  // namespace json
 }  // namespace spotify

--- a/src/encoded_value.cpp
+++ b/src/encoded_value.cpp
@@ -32,5 +32,86 @@ void encoded_value_base::validate_json(const char *data, std::size_t size) {
 
 }  // namespace detail
 
+encoded_value_ref::encoded_value_ref()
+    : _size(4),
+      _data("null") {}
+
+encoded_value_ref::encoded_value_ref(const char *data, std::size_t size)
+    : encoded_value_ref(data, size, unsafe_unchecked()) {
+  validate_json(encoded_value_ref::data(), encoded_value_ref::size());
+}
+
+void encoded_value_ref::swap(encoded_value_ref &value_ref) {
+  std::swap(_size, value_ref._size);
+  std::swap(_data, value_ref._data);
+}
+
+encoded_value::encoded_value()
+    : _size(4),
+      _data((void *) "null", [](void *) noexcept {}) {}
+
+encoded_value::~encoded_value() = default;
+
+encoded_value::encoded_value(const char *data, std::size_t size)
+    : encoded_value(data, size, unsafe_unchecked()) {
+  validate_json(encoded_value::data(), encoded_value::size());
+}
+
+encoded_value::encoded_value(encode_context &&context)
+    : encoded_value(std::move(context), unsafe_unchecked()) {
+  validate_json(data(), size());
+}
+
+encoded_value::encoded_value(const char *data, std::size_t size, const unsafe_unchecked &)
+    : _size(size),
+      _data(std::malloc(size), &std::free) {
+  if (json_unlikely(!_data && size)) {
+    throw std::bad_alloc();
+  }
+  std::memcpy(_data.get(), data, _size);
+}
+
+encoded_value &encoded_value::operator=(encoded_value &&value) noexcept {
+  swap(value);
+  return *this;
+}
+
+encoded_value &encoded_value::operator=(const encoded_value &value) {
+  encoded_value new_value(value);
+  swap(new_value);
+  return *this;
+}
+
+encoded_value &encoded_value::operator=(const encoded_value_ref &value_ref) {
+  encoded_value new_value(value_ref);
+  swap(new_value);
+  return *this;
+}
+
+void encoded_value::swap(encoded_value &value) {
+  std::swap(_size, value._size);
+  std::swap(_data, value._data);
+}
+
+std::ostream &operator <<(std::ostream &stream, const encoded_value_ref &value) {
+  stream.write(value.data(), value.size());
+  return stream;
+}
+
+std::ostream &operator <<(std::ostream &stream, const encoded_value &value) {
+  stream.write(value.data(), value.size());
+  return stream;
+}
+
+bool operator==(const encoded_value_ref &a, const encoded_value_ref &b) {
+  return
+      a.size() == b.size() &&
+      (a.data() == b.data() || std::memcmp(a.data(), b.data(), a.size()) == 0);
+}
+
+bool operator!=(const encoded_value_ref &a, const encoded_value_ref &b) {
+  return !(a == b);
+}
+
 }  // namespace json
 }  // namespace spotify

--- a/src/encoded_value.cpp
+++ b/src/encoded_value.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Spotify AB
+ * Copyright (c) 2016-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,37 +14,23 @@
  * the License.
  */
 
-#pragma once
+#include <spotify/json/encoded_value.hpp>
 
 #include <algorithm>
-#include <spotify/json/decode_context.hpp>
-#include <spotify/json/default_codec.hpp>
-#include <spotify/json/encode_context.hpp>
+#include <limits>
+#include <spotify/json/detail/cpuid.hpp>
 
 namespace spotify {
 namespace json {
-namespace codec {
+namespace detail {
 
-class string_t final {
- public:
-  using object_type = std::string;
-
-  object_type decode(decode_context &context) const;
-  void encode(encode_context &context, const object_type value) const;
-};
-
-inline string_t string() {
-  return string_t();
+void encoded_value_base::validate_json(const char *data, std::size_t size) {
+  decode_context context(data, size);
+  detail::skip_value(context);  // validate provided JSON string
+  detail::fail_if(context, context.position != context.end, "Unexpected trailing input");
 }
 
-}  // namespace codec
-
-template <>
-struct default_codec_t<std::string> {
-  static codec::string_t codec() {
-    return codec::string_t();
-  }
-};
+}  // namespace detail
 
 }  // namespace json
 }  // namespace spotify

--- a/test/src/test_encode_context.cpp
+++ b/test/src/test_encode_context.cpp
@@ -116,30 +116,6 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_append_multiple_bytes) {
   BOOST_CHECK_EQUAL(ctx.data()[1], '2');
 }
 
-BOOST_AUTO_TEST_CASE(json_encode_context_should_throw_exception_on_small_size_overflow) {
-  detail::base_encode_context<uint16_t> ctx(0);
-  ctx.reserve(UINT16_MAX);
-  ctx.advance(UINT16_MAX);
-  BOOST_CHECK_EQUAL(ctx.size(), UINT16_MAX);
-  BOOST_CHECK_EQUAL(ctx.capacity(), UINT16_MAX);
-  BOOST_CHECK_THROW(ctx.reserve(1), std::bad_alloc);
-}
-
-BOOST_AUTO_TEST_CASE(json_encode_context_should_throw_exception_on_large_size_overflow) {
-  detail::base_encode_context<uint16_t> ctx(0);
-  ctx.reserve(UINT16_MAX);
-  ctx.advance(UINT16_MAX);
-  BOOST_CHECK_EQUAL(ctx.size(), UINT16_MAX);
-  BOOST_CHECK_EQUAL(ctx.capacity(), UINT16_MAX);
-  BOOST_CHECK_THROW(ctx.reserve(UINT16_MAX), std::bad_alloc);
-}
-
-BOOST_AUTO_TEST_CASE(json_encode_context_should_saturate_capacity_on_overflow) {
-  detail::base_encode_context<uint16_t> ctx(UINT16_MAX - 20);
-  ctx.reserve(UINT16_MAX - 10);
-  BOOST_CHECK_EQUAL(ctx.capacity(), UINT16_MAX);
-}
-
 BOOST_AUTO_TEST_CASE(json_encode_context_should_let_data_be_stolen) {
   encode_context ctx;
   ctx.append('1');


### PR DESCRIPTION
These changes can be summarized as:
- Remove templates that are not really needed
- Erase types whenever possible
- Move code into .cpp files instead of the headers

These changes together reduce the size of Spotify Core by some 120 kB.