### PR TITLE
Add a codec for std:optional

### DIFF
--- a/.appveyor/build.cmd
+++ b/.appveyor/build.cmd
@@ -8,10 +8,6 @@ if "%PLATFORM%" == "" (
 mkdir build_%PLATFORM%
 pushd build_%PLATFORM%
 
-set BOOST_ROOT=%APPVEYOR_BUILD_FOLDER%\boost_1_70_0
-
-echo Boost location is '%BOOST_ROOT%'
-
 if "%PLATFORM%" == "Win32" (
   cmake -G "Visual Studio 16 2019" -A Win32 ..
 ) else if "%PLATFORM%" == "x64" (

--- a/.appveyor/build.cmd
+++ b/.appveyor/build.cmd
@@ -8,14 +8,14 @@ if "%PLATFORM%" == "" (
 mkdir build_%PLATFORM%
 pushd build_%PLATFORM%
 
-set BOOST_ROOT=%APPVEYOR_BUILD_FOLDER%\boost_1_61_0
+set BOOST_ROOT=%APPVEYOR_BUILD_FOLDER%\boost_1_70_0
 
 echo Boost location is '%BOOST_ROOT%'
 
 if "%PLATFORM%" == "Win32" (
-  cmake -G "Visual Studio 14 2015" ..
+  cmake -G "Visual Studio 16 2019" -A Win32 ..
 ) else if "%PLATFORM%" == "x64" (
-  cmake -G "Visual Studio 14 2015 Win64" ..
+  cmake -G "Visual Studio 16 2019" -A x64 ..
 ) else (
   echo Unknown platform!
   exit /b 2

--- a/.appveyor/install.cmd
+++ b/.appveyor/install.cmd
@@ -13,19 +13,3 @@ if "%PLATFORM%" == "Win32" (
   echo Unknown platform!
   exit /b 2
 )
-
-nuget install boost-vc140 -version 1.70.0 -outputdirectory boost_1_70_0 -verbosity quiet
-
-pushd boost_1_70_0
-
-mklink /d include boost.1.70.0\lib\native\include
-
-mkdir lib
-
-for /d %%i in (boost_*) do (
-  for %%j in (%%~fi\lib\native\address-model-%BITS%\lib\*) do (
-    mklink lib\%%~nxj %%~fj
-  )
-)
-
-popd

--- a/.appveyor/install.cmd
+++ b/.appveyor/install.cmd
@@ -14,11 +14,11 @@ if "%PLATFORM%" == "Win32" (
   exit /b 2
 )
 
-nuget install boost-vc140 -version 1.61.0 -outputdirectory boost_1_61_0 -verbosity quiet
+nuget install boost-vc140 -version 1.70.0 -outputdirectory boost_1_70_0 -verbosity quiet
 
-pushd boost_1_61_0
+pushd boost_1_70_0
 
-mklink /d include boost.1.61.0.0\lib\native\include
+mklink /d include boost.1.70.0\lib\native\include
 
 mkdir lib
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,27 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: bionic
       compiler: clang
       sudo: required
     - os: linux
-      dist: trusty
+      dist: bionic
       compiler: gcc
       sudo: required
     - os: linux
-      dist: trusty
+      dist: bionic
       compiler: clang
       sudo: required
       env:
         - CMAKEOPT=-DSPOTIFY_JSON_USE_SSE42=OFF
-        - VALGRIND=valgrind --leak-check=full
+        - VALGRIND='valgrind --leak-check=full'
     - os: linux
-      dist: trusty
+      dist: bionic
       compiler: gcc
       sudo: required
       env:
         - CMAKEOPT=-DSPOTIFY_JSON_USE_SSE42=OFF
-        - VALGRIND=valgrind --leak-check=full
+        - VALGRIND='valgrind --leak-check=full'
     - os: osx
       compiler: clang
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,12 @@ matrix:
         - CMAKEOPT=-DSPOTIFY_JSON_USE_SSE42=OFF
         - VALGRIND='valgrind --leak-check=full'
     - os: osx
+      osx_image: xcode11.2
       compiler: clang
       env:
         - CMAKEOPT=-DBoost_NO_BOOST_CMAKE=ON
     - os: osx
+      osx_image: xcode11.2
       compiler: gcc
       env:
         - CMAKEOPT=-DBoost_NO_BOOST_CMAKE=ON

--- a/.travis/install_linux.sh
+++ b/.travis/install_linux.sh
@@ -5,7 +5,7 @@ mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
 
 function install_boost {
   BOOST_LIBRARIES="chrono,system,test"
-  BOOST_VERSION="1.62.0"
+  BOOST_VERSION="1.70.0"
   BOOST_URL="https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//\./_}.tar.gz"
   BOOST_DIR="${DEPS_DIR}/boost"
   echo "Downloading Boost ${BOOST_VERSION} from ${BOOST_URL}"
@@ -27,6 +27,7 @@ function install_cmake {
 }
 
 function install_valgrind {
+  echo "Installing valgrind ..."
   sudo apt-get update -qq
   sudo apt-get install -qq valgrind
 }

--- a/.travis/install_linux.sh
+++ b/.travis/install_linux.sh
@@ -16,8 +16,8 @@ function install_boost {
 }
 
 function install_cmake {
-  CMAKE_VERSION="3.6.2"
-  CMAKE_URL="https://cmake.org/files/v3.6/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+  CMAKE_VERSION="3.15.5"
+  CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
   CMAKE_DIR="${DEPS_DIR}/cmake"
   CMAKE_BIN="${CMAKE_DIR}/bin"
   echo "Downloading CMake ${CMAKE_VERSION} from ${CMAKE_URL}"
@@ -32,7 +32,7 @@ function install_valgrind {
 }
 
 install_boost # at least version 1.60
-install_cmake # at least version 3.2
+install_cmake # at least version 3.15
 install_valgrind # at least version 3.7
 echo "Installed build dependecies."
 echo "  - Boost: ${BOOST_ROOT}"

--- a/.travis/install_osx.sh
+++ b/.travis/install_osx.sh
@@ -10,5 +10,5 @@ function install_or_upgrade {
 }
 
 install_or_upgrade boost # at least version 1.60
-install_or_upgrade cmake # at least version 3.2
+install_or_upgrade cmake # at least version 3.15
 echo "Installed build dependecies."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.2.0)
 project(spotify-json)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(json_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(json_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
 
 set(json_HEADERS
   include/spotify/json.hpp
+  include/spotify/json/codec.hpp
   include/spotify/json/default_codec.hpp
   include/spotify/json/decode.hpp
   include/spotify/json/decode_exception.hpp
@@ -49,6 +50,7 @@ set(json_codec_HEADERS
   include/spotify/json/codec/boost.hpp
   include/spotify/json/codec/cast.hpp
   include/spotify/json/codec/chrono.hpp
+  include/spotify/json/codec/codec.hpp
   include/spotify/json/codec/codec_interface.hpp
   include/spotify/json/codec/empty_as.hpp
   include/spotify/json/codec/enumeration.hpp
@@ -60,6 +62,7 @@ set(json_codec_HEADERS
   include/spotify/json/codec/object.hpp
   include/spotify/json/codec/omit.hpp
   include/spotify/json/codec/one_of.hpp
+  include/spotify/json/codec/optional.hpp
   include/spotify/json/codec/smart_ptr.hpp
   include/spotify/json/codec/string.hpp
   include/spotify/json/codec/transform.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 3.15.0)
 project(spotify-json)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ spotify-json
 [![macOS & Linux Builds](https://img.shields.io/travis/spotify/spotify-json/master.svg?style=flat)](https://travis-ci.org/spotify/spotify-json)
 [![Windows Build](https://ci.appveyor.com/api/projects/status/github/spotify/spotify-json?svg=true)](https://ci.appveyor.com/project/fxb/spotify-json)
 
-A C++11 JSON writer and parser library. It
+A C++17 JSON writer and parser library. It
 
 * parses and serializes directly to and from statically typed C++ objects,
 * requires very little boilerplate code,
 * is fast and makes use of vectorization,
 * supports UTF-8,
 * comes with [a good suite of tests](test),
-* is deployed and in active use on well over 100 million devices,
+* is deployed and in active use on over 250 million devices,
 * and [has API documentation](doc/api.md).
 
 spotify-json depends on [Google's double-conversion library](https://github.com/google/double-conversion),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ matrix:
 
 image: Visual Studio 2019
 
+environment:
+  BOOST_ROOT: C:\Libraries\boost_1_71_0
+
 install:
   - cmd: .appveyor\install.cmd
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ configuration:
 matrix:
   fast_finish: true
 
+image: Visual Studio 2019
+
 install:
   - cmd: .appveyor\install.cmd
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -1022,14 +1022,12 @@ to `std::nullopt`) are not encoded at all (`should_encode()` returns `false`).
 To encode `std::nullopt` as `null`, use the [`empty_as_t`](#empty_as_t) codec,
 e.g., `spotify::json::empty_as_null()`.
 
-This codec is in header `<spotify/json/optional.hpp>`.
-
 * **Complete class name**: `spotify::json::codec::optional_t`
 * **Supported types**: `std::optional<T>`
 * **Convenience builder**: `spotify::json::codec::optional`
 * **`default_codec` support**: `default_codec<std::optional<T>>()`
 
-For `boost::optional`, include header `<spotify/json/boost.hpp>`.
+For `boost::optional`, include header `<spotify/json/codec/boost.hpp>`.
 
 `boost_optional_t` is a codec for for `boost::optional<T>`. Uninitialized values
 (equivalent to `boost::none`) are not encoded at all (`should_encode()` returns
@@ -1047,7 +1045,7 @@ spotify-json provides support for `duration` and `time_point` types of
 `std::chrono` and `boost::chrono`. They are implemented using `transform_t`, so
 they don't have `*_t` classes like many of the other codecs.
 
-For `boost::chrono`, include header `<spotify/json/boost.hpp>`.
+For `boost::chrono`, include header `<spotify/json/codec/boost.hpp>`.
 
 * **Complete class name**: N/A. See above.
 * **Supported types**: All `std::chrono::duration`, `std::chrono::time_point`,

--- a/doc/api.md
+++ b/doc/api.md
@@ -232,7 +232,7 @@ a number of codecs that are available to the user of the library:
 * [`transform_t`](#transform_t): For types that the library doesn't have built
   in support for.
 * [`tuple_t`](#tuple_t): For `std::pair` and `std::tuple`.
-* [`optional_t`](#optional): For `boost::optional`
+* [`optional_t`](#optional): For `std::optional` and `boost::optional`
 * [Chrono codecs](#chrono): spotify-json provides support for `std::chrono` and
   `boost::chrono` types.
 
@@ -1017,16 +1017,28 @@ const auto point = decode(codec, "[1,3]");
 
 ### `optional_t`
 
-`optional_t` is a codec for strings for `boost::optional<T>`. Uninitialized
-values (equivalent to `boost::none`) are not encoded at all (`should_encode()`
-returns `false`). To encode `boost::none` as `null`, use the
-[`empty_as_t`](#empty_as_t) codec, e.g., `spotify::json::empty_as_null()`.
+`optional_t` is a codec for `std::optional<T>`. Uninitialized values (equivalent
+to `std::nullopt`) are not encoded at all (`should_encode()` returns `false`).
+To encode `std::nullopt` as `null`, use the [`empty_as_t`](#empty_as_t) codec,
+e.g., `spotify::json::empty_as_null()`.
 
-This codec is in header `<spotify/json/boost.hpp>`.
+This codec is in header `<spotify/json/optional.hpp>`.
 
 * **Complete class name**: `spotify::json::codec::optional_t`
 * **Supported types**: `std::optional<T>`
 * **Convenience builder**: `spotify::json::codec::optional`
+* **`default_codec` support**: `default_codec<std::optional<T>>()`
+
+For `boost::optional`, include header `<spotify/json/boost.hpp>`.
+
+`boost_optional_t` is a codec for for `boost::optional<T>`. Uninitialized values
+(equivalent to `boost::none`) are not encoded at all (`should_encode()` returns
+`false`). To encode `boost::none` as `null`, use the [`empty_as_t`](#empty_as_t)
+codec, e.g., `spotify::json::empty_as_null()`.
+
+* **Complete class name**: `spotify::json::codec::boost_optional_t`
+* **Supported types**: `boost::optional<T>`
+* **Convenience builder**: `spotify::json::codec::boost_optional`
 * **`default_codec` support**: `default_codec<boost::optional<T>>()`
 
 ### chrono

--- a/include/spotify/json/codec/boost.hpp
+++ b/include/spotify/json/codec/boost.hpp
@@ -60,9 +60,9 @@ struct codec_cast<boost::shared_ptr<T>, boost::shared_ptr<F>> {
 template <typename codec_type>
 using boost_optional_t = optional_t<codec_type, boost::optional<typename codec_type::object_type>, boost::none_t>;
 
-template <typename codec_type, typename... options_type>
-boost_optional_t<typename std::decay<codec_type>::type> boost_optional(codec_type &&inner_codec, options_type... options) {
-  return boost_optional_t<typename std::decay<codec_type>::type>(std::forward<codec_type>(inner_codec), options...);
+template <typename codec_type>
+boost_optional_t<typename std::decay<codec_type>::type> boost_optional(codec_type &&inner_codec) {
+  return boost_optional_t<typename std::decay<codec_type>::type>(std::forward<codec_type>(inner_codec));
 }
 
 }  // namespace codec

--- a/include/spotify/json/codec/codec.hpp
+++ b/include/spotify/json/codec/codec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Spotify AB
+ * Copyright (c) 2015-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,6 +32,7 @@
 #include <spotify/json/codec/object.hpp>
 #include <spotify/json/codec/omit.hpp>
 #include <spotify/json/codec/one_of.hpp>
+#include <spotify/json/codec/optional.hpp>
 #include <spotify/json/codec/smart_ptr.hpp>
 #include <spotify/json/codec/string.hpp>
 #include <spotify/json/codec/transform.hpp>

--- a/include/spotify/json/codec/optional.hpp
+++ b/include/spotify/json/codec/optional.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <type_traits>
+#include <spotify/json/detail/decode_helpers.hpp>
+#include <spotify/json/detail/encode_helpers.hpp>
+
+namespace spotify {
+namespace json {
+namespace codec {
+
+template <
+    typename codec_type,
+    typename optional_type = std::optional<typename codec_type::object_type>,
+    typename nullopt_type = std::nullopt_t>
+class optional_t {
+ public:
+  using object_type = optional_type;
+
+  explicit optional_t(codec_type &&inner_codec) : _inner_codec(std::move(inner_codec)) {}
+  explicit optional_t(const codec_type &inner_codec) : _inner_codec(inner_codec) {}
+
+  object_type decode(decode_context &context) const {
+    return _inner_codec.decode(context);
+  }
+
+  template <typename value_type>
+  void encode(encode_context &context, const value_type &value) const {
+    detail::fail_if(context, !value, "Cannot encode null optional");
+    _inner_codec.encode(context, *value);
+  }
+
+  template <typename value_type>
+  bool should_encode(const value_type &value) const {
+    return value && detail::should_encode(_inner_codec, *value);
+  }
+
+  bool should_encode(const nullopt_type &) const {
+    return false;
+  }
+
+ private:
+  codec_type _inner_codec;
+};
+
+template <typename codec_type, typename... options_type>
+optional_t<typename std::decay<codec_type>::type> optional(codec_type &&inner_codec, options_type... options) {
+  return optional_t<typename std::decay<codec_type>::type>(std::forward<codec_type>(inner_codec), options...);
+}
+
+}  // namespace codec
+
+template <typename T>
+struct default_codec_t<std::optional<T>> {
+  static decltype(codec::optional(default_codec<T>())) codec() {
+    return codec::optional(default_codec<T>());
+  }
+};
+
+}  // namespace json
+}  // namespace spotify

--- a/include/spotify/json/codec/optional.hpp
+++ b/include/spotify/json/codec/optional.hpp
@@ -59,9 +59,9 @@ class optional_t {
   codec_type _inner_codec;
 };
 
-template <typename codec_type, typename... options_type>
-optional_t<typename std::decay<codec_type>::type> optional(codec_type &&inner_codec, options_type... options) {
-  return optional_t<typename std::decay<codec_type>::type>(std::forward<codec_type>(inner_codec), options...);
+template <typename codec_type>
+optional_t<typename std::decay<codec_type>::type> optional(codec_type &&inner_codec) {
+  return optional_t<typename std::decay<codec_type>::type>(std::forward<codec_type>(inner_codec));
 }
 
 }  // namespace codec

--- a/include/spotify/json/detail/decode_helpers.hpp
+++ b/include/spotify/json/detail/decode_helpers.hpp
@@ -130,7 +130,7 @@ json_force_inline void skip_1(decode_context &context, char character) {
  */
 json_force_inline void skip_4(decode_context &context, const char characters[4]) {
   require_bytes<4>(context);
-  fail_if(context, memcmp(characters, context.position, 4), "Unexpected input");
+  fail_if(context, memcmp(characters, context.position, 4) != 0, "Unexpected input");
   context.position += 4;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2016 Spotify AB
+# Copyright (c) 2014-2019 Spotify AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -66,7 +66,7 @@ source_group(spotify\\json\\test FILES ${spotify_json_test_HEADERS})
 
 add_executable(${spotify_json_test_TARGET} ${spotify_json_test_SOURCES} ${spotify_json_test_HEADERS})
 
-set_property(TARGET ${spotify_json_test_TARGET} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${spotify_json_test_TARGET} PROPERTY CXX_STANDARD 17)
 set_property(TARGET ${spotify_json_test_TARGET} PROPERTY CXX_STANDARD_REQUIRED ON)
 
 if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ set(spotify_json_test_SOURCES
   src/test_object.cpp
   src/test_omit.cpp
   src/test_one_of.cpp
+  src/test_optional.cpp
   src/test_skip_chars.cpp
   src/test_skip_value.cpp
   src/test_smart_ptr.cpp

--- a/test/src/test_boost.cpp
+++ b/test/src/test_boost.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Spotify AB
+ * Copyright (c) 2015-2019 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -99,12 +99,12 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_shared_ptr_should_not_encode_null) {
  */
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_construct) {
-  const auto c = codec::optional_t<codec::string_t>(codec::string());
+  const auto c = codec::boost_optional_t<codec::string_t>(codec::string());
   static_cast<void>(c);
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_construct_with_helper) {
-  const auto c = codec::optional((codec::string()));
+  const auto c = codec::boost_optional((codec::string()));
   static_cast<void>(c);
 }
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_implement_should_encode) {
 }
 
 BOOST_AUTO_TEST_CASE(json_codec_boost_optional_should_forward_should_encode) {
-  const auto codec = codec::optional_t<codec::omit_t<std::string>>(codec::omit<std::string>());
+  const auto codec = codec::boost_optional_t<codec::omit_t<std::string>>(codec::omit<std::string>());
   BOOST_CHECK(!codec.should_encode(boost::make_optional(std::string(""))));
 }
 

--- a/test/src/test_encode_context.cpp
+++ b/test/src/test_encode_context.cpp
@@ -59,13 +59,6 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_return_same_address_for_multiple
   BOOST_CHECK(address_0 == address_2);
 }
 
-BOOST_AUTO_TEST_CASE(json_encode_context_should_advance_pointer_after_reservation) {
-  encode_context ctx(0);
-  ctx.advance(0); BOOST_CHECK(ctx.reserve(1024) == &ctx.data()[0]);
-  ctx.advance(1); BOOST_CHECK(ctx.reserve(1024) == &ctx.data()[1]);
-  ctx.advance(2); BOOST_CHECK(ctx.reserve(1024) == &ctx.data()[3]);
-}
-
 BOOST_AUTO_TEST_CASE(json_encode_context_should_maintain_correct_size_when_advancing) {
   encode_context ctx(0);
   ctx.advance(1);

--- a/test/src/test_encode_context.cpp
+++ b/test/src/test_encode_context.cpp
@@ -59,6 +59,19 @@ BOOST_AUTO_TEST_CASE(json_encode_context_should_return_same_address_for_multiple
   BOOST_CHECK(address_0 == address_2);
 }
 
+BOOST_AUTO_TEST_CASE(json_encode_context_should_advance_pointer_after_reservation) {
+  encode_context ctx(0);
+  ctx.advance(0);
+  const auto r0 = ctx.reserve(1024);
+  BOOST_CHECK(r0 == &ctx.data()[0]);
+  ctx.advance(1);
+  const auto r1 = ctx.reserve(1024);
+  BOOST_CHECK(r1 == &ctx.data()[1]);
+  ctx.advance(2);
+  const auto r3 = ctx.reserve(1024);
+  BOOST_CHECK(r3 == &ctx.data()[3]);
+}
+
 BOOST_AUTO_TEST_CASE(json_encode_context_should_maintain_correct_size_when_advancing) {
   encode_context ctx(0);
   ctx.advance(1);

--- a/test/src/test_optional.cpp
+++ b/test/src/test_optional.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <optional>
+#include <string>
+#include <spotify/json/codec/any_value.hpp>
+#include <spotify/json/codec/optional.hpp>
+#include <spotify/json/codec/object.hpp>
+#include <spotify/json/codec/omit.hpp>
+#include <spotify/json/codec/string.hpp>
+#include <spotify/json/decode.hpp>
+#include <spotify/json/encode.hpp>
+#include <spotify/json/encoded_value.hpp>
+#include <spotify/json/test/only_true.hpp>
+
+BOOST_AUTO_TEST_SUITE(spotify)
+BOOST_AUTO_TEST_SUITE(json)
+BOOST_AUTO_TEST_SUITE(codec)
+
+namespace {
+
+struct optional_value_ref { std::optional<encoded_value_ref> value = encoded_value_ref("{}"); };
+
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_construct) {
+  const auto c = codec::optional_t<codec::string_t>(codec::string());
+  static_cast<void>(c);
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_construct_with_helper) {
+  const auto c = codec::optional((codec::string()));
+  static_cast<void>(c);
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_construct_with_default_codec) {
+  default_codec<std::optional<std::string>>();
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_encode_string) {
+  const auto codec = default_codec<std::optional<std::string>>();
+  BOOST_CHECK_EQUAL(encode(codec, std::make_optional(std::string("hi"))), "\"hi\"");
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_encode_size_t) {
+  const auto codec = default_codec<std::optional<size_t>>();
+  BOOST_CHECK_EQUAL(encode(codec, std::make_optional(size_t(123456))), "123456");
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_decode) {
+  const auto codec = default_codec<std::optional<std::string>>();
+  BOOST_CHECK(decode(codec, "\"hi\"") == std::make_optional(std::string("hi")));
+
+  std::optional<std::string> value;
+  BOOST_CHECK(!try_decode(value, codec, "\"hi"));
+  BOOST_CHECK(!try_decode(value, codec, ""));
+  BOOST_CHECK(!try_decode(value, codec, "5"));
+  BOOST_CHECK(!try_decode(value, codec, "null"));
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_implement_should_encode) {
+  const auto codec = default_codec<std::optional<std::string>>();
+  BOOST_CHECK(codec.should_encode(std::make_optional(std::string(""))));
+  BOOST_CHECK(!codec.should_encode(std::nullopt));
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_forward_should_encode) {
+  const auto codec = codec::optional_t<codec::omit_t<std::string>>(codec::omit<std::string>());
+  BOOST_CHECK(!codec.should_encode(std::make_optional(std::string(""))));
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_accept_encoded_value_ref) {
+  const auto value = std::optional<encoded_value_ref>(encoded_value_ref("{}"));
+  const auto codec = default_codec<std::optional<encoded_value_ref>>();
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(value) == "{}");
+  BOOST_CHECK(decode(codec, "{}").value() == value.value());
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_accept_encoded_value) {
+  const auto value = std::optional<encoded_value>(encoded_value("{}"));
+  const auto codec = default_codec<std::optional<encoded_value>>();
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(value) == "{}");
+  BOOST_CHECK(decode(codec, "{}").value() == value.value());
+}
+
+BOOST_AUTO_TEST_CASE(json_codec_optional_should_accept_encoded_value_ref_in_object) {
+  codec::object_t<optional_value_ref> codec;
+  codec.optional("value", &optional_value_ref::value);
+
+  const optional_value_ref value{};
+  BOOST_CHECK(detail::should_encode(codec, value));
+  BOOST_CHECK(encode(codec, value) == "{\"value\":{}}");
+  BOOST_CHECK(decode(codec, "{\"value\":{}}").value.value() == value.value.value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()  // codec
+BOOST_AUTO_TEST_SUITE_END()  // json
+BOOST_AUTO_TEST_SUITE_END()  // spotify


### PR DESCRIPTION
`std::optional` comes with C++17, and with this PR, we are raising the minimum C++ version from C++11 to C++17. While possible to try to retain full compatibility with C++11 using some preprocessor coding plus some changes to the `optional_t` codec, I don't feel it is worth the added complexity. This JSON library is pretty stable by now, so most additions will be support for newer C++ datatypes. Applications that wish to compile as C++11 can stick to the older versions of `spotify-json` without missing out on anything.