### PR TITLE
use proper memory management on realloc errors

### DIFF
--- a/src/encode_context.cpp
+++ b/src/encode_context.cpp
@@ -68,11 +68,12 @@ char *encode_context::grow_buffer(const std::size_t num_bytes) {
   // is at least as large as the reserved size. We avoid doing any arithmetics
   // here to not have to check for overflow yet again.
   const auto actual_capacity = std::max(new_size, new_capacity);
-  _buf = static_cast<char *>(std::realloc(_buf, actual_capacity));
-  if (json_unlikely(!_buf)) {
+  auto* new_buf = static_cast<char *>(std::realloc(_buf, actual_capacity));
+  if (json_unlikely(!new_buf)) {
     throw std::bad_alloc();
   }
 
+  _buf = new_buf;
   _ptr = _buf + old_size;
   _end = _buf + actual_capacity;
   _capacity = actual_capacity;


### PR DESCRIPTION
If `realloc()` is not able to allocate memory it returns `nullptr`. In case of such error the old code assigned `nullptr` to `_buf` and threw. The unwinding (the dtor `~encode_context::~encode_context()`) is not able to free memory which causes a memory leak. We have to assign a new pointer to `_buf` only if `realloc()` succeeded.