### PR TITLE
Bump double-conversion

### DIFF
--- a/vendor/double-conversion/.gitignore
+++ b/vendor/double-conversion/.gitignore
@@ -27,3 +27,5 @@ _deps
 *.cmake
 *.kdev4
 DartConfiguration.tcl
+bazel-*
+

--- a/vendor/double-conversion/BUILD
+++ b/vendor/double-conversion/BUILD
@@ -1,5 +1,7 @@
 # Bazel(http://bazel.io) BUILD file
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 licenses(["notice"])
 
 exports_files(["LICENSE"])
@@ -10,12 +12,11 @@ cc_library(
         "double-conversion/bignum.cc",
         "double-conversion/bignum-dtoa.cc",
         "double-conversion/cached-powers.cc",
-        "double-conversion/diy-fp.cc",
-        "double-conversion/double-conversion.cc",
+        "double-conversion/double-to-string.cc",
         "double-conversion/fast-dtoa.cc",
         "double-conversion/fixed-dtoa.cc",
+        "double-conversion/string-to-double.cc",
         "double-conversion/strtod.cc",
-        "double-conversion/utils.h",
     ],
     hdrs = [
         "double-conversion/bignum.h",
@@ -23,10 +24,13 @@ cc_library(
         "double-conversion/cached-powers.h",
         "double-conversion/diy-fp.h",
         "double-conversion/double-conversion.h",
+        "double-conversion/double-to-string.h",
         "double-conversion/fast-dtoa.h",
         "double-conversion/fixed-dtoa.h",
         "double-conversion/ieee.h",
+        "double-conversion/string-to-double.h",
         "double-conversion/strtod.h",
+        "double-conversion/utils.h",
     ],
     linkopts = [
         "-lm",

--- a/vendor/double-conversion/CMakeLists.txt
+++ b/vendor/double-conversion/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 project(double-conversion VERSION 3.1.5)
 
+if(BUILD_SHARED_LIBS AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 set(headers
     double-conversion/bignum.h
     double-conversion/cached-powers.h

--- a/vendor/double-conversion/Changelog
+++ b/vendor/double-conversion/Changelog
@@ -1,3 +1,10 @@
+2020-02-16:
+  Add support for quiet and signaling NaNs to ieee header.
+
+2019-10-31:
+  Add support for xtensa architecture.
+  Add support for nios2 architecture.
+
 2019-10-12:
   Really add support for microblaze. A previous commit was lacking
 	the necessary line.

--- a/vendor/double-conversion/double-conversion/bignum-dtoa.cc
+++ b/vendor/double-conversion/double-conversion/bignum-dtoa.cc
@@ -370,7 +370,7 @@ static void BignumToFixed(int requested_digits, int* decimal_point,
 // Returns an estimation of k such that 10^(k-1) <= v < 10^k where
 // v = f * 2^exponent and 2^52 <= f < 2^53.
 // v is hence a normalized double with the given exponent. The output is an
-// approximation for the exponent of the decimal approimation .digits * 10^k.
+// approximation for the exponent of the decimal approximation .digits * 10^k.
 //
 // The result might undershoot by 1 in which case 10^k <= v < 10^k+1.
 // Note: this property holds for v's upper boundary m+ too.
@@ -548,7 +548,7 @@ static void InitialScaledStartValuesNegativeExponentNegativePower(
 //
 // Let ep == estimated_power, then the returned values will satisfy:
 //  v / 10^ep = numerator / denominator.
-//  v's boundarys m- and m+:
+//  v's boundaries m- and m+:
 //    m- / 10^ep == v / 10^ep - delta_minus / denominator
 //    m+ / 10^ep == v / 10^ep + delta_plus / denominator
 //  Or in other words:

--- a/vendor/double-conversion/double-conversion/ieee.h
+++ b/vendor/double-conversion/double-conversion/ieee.h
@@ -45,6 +45,7 @@ class Double {
   static const uint64_t kExponentMask = DOUBLE_CONVERSION_UINT64_2PART_C(0x7FF00000, 00000000);
   static const uint64_t kSignificandMask = DOUBLE_CONVERSION_UINT64_2PART_C(0x000FFFFF, FFFFFFFF);
   static const uint64_t kHiddenBit = DOUBLE_CONVERSION_UINT64_2PART_C(0x00100000, 00000000);
+  static const uint64_t kQuietNanBit = DOUBLE_CONVERSION_UINT64_2PART_C(0x00080000, 00000000);
   static const int kPhysicalSignificandSize = 52;  // Excludes the hidden bit.
   static const int kSignificandSize = 53;
   static const int kExponentBias = 0x3FF + kPhysicalSignificandSize;
@@ -147,6 +148,15 @@ class Double {
     return ((d64 & kExponentMask) == kExponentMask) &&
         ((d64 & kSignificandMask) != 0);
   }
+
+  bool IsQuietNan() const {
+    return IsNan() && ((AsUint64() & kQuietNanBit) != 0);
+  }
+
+  bool IsSignalingNan() const {
+    return IsNan() && ((AsUint64() & kQuietNanBit) == 0);
+  }
+
 
   bool IsInfinite() const {
     uint64_t d64 = AsUint64();
@@ -266,6 +276,7 @@ class Single {
   static const uint32_t kExponentMask = 0x7F800000;
   static const uint32_t kSignificandMask = 0x007FFFFF;
   static const uint32_t kHiddenBit = 0x00800000;
+  static const uint32_t kQuietNanBit = 0x00400000;
   static const int kPhysicalSignificandSize = 23;  // Excludes the hidden bit.
   static const int kSignificandSize = 24;
 
@@ -323,6 +334,15 @@ class Single {
     return ((d32 & kExponentMask) == kExponentMask) &&
         ((d32 & kSignificandMask) != 0);
   }
+
+  bool IsQuietNan() const {
+    return IsNan() && ((AsUint32() & kQuietNanBit) != 0);
+  }
+
+  bool IsSignalingNan() const {
+    return IsNan() && ((AsUint32() & kQuietNanBit) == 0);
+  }
+
 
   bool IsInfinite() const {
     uint32_t d32 = AsUint32();

--- a/vendor/double-conversion/double-conversion/string-to-double.cc
+++ b/vendor/double-conversion/double-conversion/string-to-double.cc
@@ -441,11 +441,6 @@ double StringToDoubleConverter::StringToIeee(
     }
   }
 
-  // The longest form of simplified number is: "-<significant digits>.1eXXX\0".
-  const int kBufferSize = kMaxSignificantDigits + 10;
-  char buffer[kBufferSize];  // NOLINT: size is known at compile time.
-  int buffer_pos = 0;
-
   // Exponent will be adjusted if insignificant digits of the integer part
   // or insignificant leading zeros of the fractional part are dropped.
   int exponent = 0;
@@ -480,7 +475,6 @@ double StringToDoubleConverter::StringToIeee(
         return junk_string_value_;
       }
 
-      DOUBLE_CONVERSION_ASSERT(buffer_pos == 0);
       *processed_characters_count = static_cast<int>(current - input);
       return sign ? -Double::Infinity() : Double::Infinity();
     }
@@ -499,7 +493,6 @@ double StringToDoubleConverter::StringToIeee(
         return junk_string_value_;
       }
 
-      DOUBLE_CONVERSION_ASSERT(buffer_pos == 0);
       *processed_characters_count = static_cast<int>(current - input);
       return sign ? -Double::NaN() : Double::NaN();
     }
@@ -555,6 +548,12 @@ double StringToDoubleConverter::StringToIeee(
   }
 
   bool octal = leading_zero && (flags_ & ALLOW_OCTALS) != 0;
+
+  // The longest form of simplified number is: "-<significant digits>.1eXXX\0".
+  const int kBufferSize = kMaxSignificantDigits + 10;
+  DOUBLE_CONVERSION_STACK_UNINITIALIZED char
+      buffer[kBufferSize];  // NOLINT: size is known at compile time.
+  int buffer_pos = 0;
 
   // Copy significant digits of the integer part (if any) to the buffer.
   while (*current >= '0' && *current <= '9') {

--- a/vendor/double-conversion/double-conversion/strtod.cc
+++ b/vendor/double-conversion/double-conversion/strtod.cc
@@ -35,10 +35,12 @@
 
 namespace double_conversion {
 
+#if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 // 2^53 = 9007199254740992.
 // Any integer with at most 15 decimal digits will hence fit into a double
 // (which has a 53bit significand) without loss of precision.
 static const int kMaxExactDoubleIntegerDecimalDigits = 15;
+#endif // #if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 // 2^64 = 18446744073709551616 > 10^19
 static const int kMaxUint64DecimalDigits = 19;
 
@@ -55,6 +57,7 @@ static const int kMinDecimalPower = -324;
 static const uint64_t kMaxUint64 = DOUBLE_CONVERSION_UINT64_2PART_C(0xFFFFFFFF, FFFFFFFF);
 
 
+#if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 static const double exact_powers_of_ten[] = {
   1.0,  // 10^0
   10.0,
@@ -82,6 +85,7 @@ static const double exact_powers_of_ten[] = {
   10000000000000000000000.0
 };
 static const int kExactPowersOfTenSize = DOUBLE_CONVERSION_ARRAY_SIZE(exact_powers_of_ten);
+#endif // #if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 
 // Maximum number of significant digits in the decimal representation.
 // In fact the value is 772 (see conversions.cc), but to give us some margin
@@ -202,8 +206,6 @@ static bool DoubleStrtod(Vector<const char> trimmed,
   // 80 bits wide (as is the case on Linux) then double-rounding occurs and the
   // result is not accurate.
   // We know that Windows32 uses 64 bits and is therefore accurate.
-  // Note that the ARM simulator is compiled for 32bits. It therefore exhibits
-  // the same problem.
   return false;
 #else
   if (trimmed.length() <= kMaxExactDoubleIntegerDecimalDigits) {

--- a/vendor/double-conversion/double-conversion/utils.h
+++ b/vendor/double-conversion/double-conversion/utils.h
@@ -56,12 +56,26 @@ inline void abort_noreturn() { abort(); }
 #endif
 #endif
 
+// Not all compilers support __has_attribute and combining a check for both
+// ifdef and __has_attribute on the same preprocessor line isn't portable.
+#ifdef __has_attribute
+#   define DOUBLE_CONVERSION_HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+#   define DOUBLE_CONVERSION_HAS_ATTRIBUTE(x) 0
+#endif
+
 #ifndef DOUBLE_CONVERSION_UNUSED
-#ifdef __GNUC__
+#if DOUBLE_CONVERSION_HAS_ATTRIBUTE(unused)
 #define DOUBLE_CONVERSION_UNUSED __attribute__((unused))
 #else
 #define DOUBLE_CONVERSION_UNUSED
 #endif
+#endif
+
+#if DOUBLE_CONVERSION_HAS_ATTRIBUTE(uninitialized)
+#define DOUBLE_CONVERSION_STACK_UNINITIALIZED __attribute__((uninitialized))
+#else
+#define DOUBLE_CONVERSION_STACK_UNINITIALIZED
 #endif
 
 // Double operations detection based on target architecture.
@@ -94,6 +108,7 @@ int main(int argc, char** argv) {
     defined(__ARMEL__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
     defined(__hppa__) || defined(__ia64__) || \
     defined(__mips__) || \
+    defined(__nios2__) || \
     defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
     defined(_POWER) || defined(_ARCH_PPC) || defined(_ARCH_PPC64) || \
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
@@ -102,8 +117,8 @@ int main(int argc, char** argv) {
     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
     defined(__riscv) || defined(__e2k__) || \
     defined(__or1k__) || defined(__arc__) || \
-    defined(__microblaze__) || \
-    defined(__EMSCRIPTEN__)
+    defined(__microblaze__) || defined(__XTENSA__) || \
+    defined(__EMSCRIPTEN__) || defined(__wasm32__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(__mc68000__) || \
     defined(__pnacl__) || defined(__native_client__)

--- a/vendor/double-conversion/msvc/double-conversion.vcxproj
+++ b/vendor/double-conversion/msvc/double-conversion.vcxproj
@@ -147,24 +147,25 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\double-conversion\bignum-dtoa.cc" />
     <ClCompile Include="..\double-conversion\bignum.cc" />
+    <ClCompile Include="..\double-conversion\bignum-dtoa.cc" />
     <ClCompile Include="..\double-conversion\cached-powers.cc" />
-    <ClCompile Include="..\double-conversion\diy-fp.cc" />
-    <ClCompile Include="..\double-conversion\double-conversion.cc" />
+    <ClCompile Include="..\double-conversion\double-to-string.cc" />
     <ClCompile Include="..\double-conversion\fast-dtoa.cc" />
     <ClCompile Include="..\double-conversion\fixed-dtoa.cc" />
+    <ClCompile Include="..\double-conversion\string-to-double.cc" />
     <ClCompile Include="..\double-conversion\strtod.cc" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\double-conversion\bignum-dtoa.h" />
     <ClInclude Include="..\double-conversion\bignum.h" />
     <ClInclude Include="..\double-conversion\cached-powers.h" />
     <ClInclude Include="..\double-conversion\diy-fp.h" />
     <ClInclude Include="..\double-conversion\double-conversion.h" />
+    <ClInclude Include="..\double-conversion\double-to-string.h" />
     <ClInclude Include="..\double-conversion\fast-dtoa.h" />
     <ClInclude Include="..\double-conversion\fixed-dtoa.h" />
     <ClInclude Include="..\double-conversion\ieee.h" />
+    <ClInclude Include="..\double-conversion\string-to-double.h" />
     <ClInclude Include="..\double-conversion\strtod.h" />
     <ClInclude Include="..\double-conversion\utils.h" />
   </ItemGroup>

--- a/vendor/double-conversion/msvc/double-conversion.vcxproj.filters
+++ b/vendor/double-conversion/msvc/double-conversion.vcxproj.filters
@@ -24,12 +24,6 @@
     <ClCompile Include="..\double-conversion\cached-powers.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\double-conversion\diy-fp.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\double-conversion\double-conversion.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\double-conversion\fast-dtoa.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -39,12 +33,15 @@
     <ClCompile Include="..\double-conversion\strtod.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\double-conversion\double-to-string.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\double-conversion\string-to-double.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\double-conversion\bignum.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\double-conversion\bignum-dtoa.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\double-conversion\cached-powers.h">
@@ -69,6 +66,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\double-conversion\utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\double-conversion\double-to-string.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\double-conversion\string-to-double.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vendor/double-conversion/msvc/run_tests/run_tests.vcxproj
+++ b/vendor/double-conversion/msvc/run_tests/run_tests.vcxproj
@@ -109,6 +109,7 @@
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/vendor/double-conversion/test/cctest/CMakeLists.txt
+++ b/vendor/double-conversion/test/cctest/CMakeLists.txt
@@ -18,6 +18,9 @@ set(CCTEST_SRC
 
 add_executable(cctest ${CCTEST_SRC})
 target_link_libraries(cctest double-conversion)
+if(MSVC)
+    target_compile_options(cctest PRIVATE /bigobj)
+endif()
 
 add_test(NAME test_bignum
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/vendor/double-conversion/test/cctest/test-conversions.cc
+++ b/vendor/double-conversion/test/cctest/test-conversions.cc
@@ -1,4 +1,29 @@
 // Copyright 2012 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string.h>
 

--- a/vendor/double-conversion/test/cctest/test-diy-fp.cc
+++ b/vendor/double-conversion/test/cctest/test-diy-fp.cc
@@ -1,4 +1,29 @@
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
 

--- a/vendor/double-conversion/test/cctest/test-fast-dtoa.cc
+++ b/vendor/double-conversion/test/cctest/test-fast-dtoa.cc
@@ -1,4 +1,29 @@
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
 

--- a/vendor/double-conversion/test/cctest/test-ieee.cc
+++ b/vendor/double-conversion/test/cctest/test-ieee.cc
@@ -1,6 +1,32 @@
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
+#include <limits>
 
 #include "cctest.h"
 #include "double-conversion/diy-fp.h"
@@ -418,4 +444,20 @@ TEST(PreviousDouble) {
   CHECK_EQ(1.7976931348623157e308, Double(Double::Infinity()).PreviousDouble());
   CHECK_EQ(-Double::Infinity(),
            Double(DOUBLE_CONVERSION_UINT64_2PART_C(0xffefffff, ffffffff)).PreviousDouble());
+}
+
+TEST(SignalingNan) {
+  Double nan(Double::NaN());
+  CHECK(nan.IsNan());
+  CHECK(nan.IsQuietNan());
+  CHECK(Double(std::numeric_limits<double>::quiet_NaN()).IsQuietNan());
+  CHECK(Double(std::numeric_limits<double>::signaling_NaN()).IsSignalingNan());
+}
+
+TEST(SignalingNanSingle) {
+  Single nan(Single::NaN());
+  CHECK(nan.IsNan());
+  CHECK(nan.IsQuietNan());
+  CHECK(Single(std::numeric_limits<float>::quiet_NaN()).IsQuietNan());
+  CHECK(Single(std::numeric_limits<float>::signaling_NaN()).IsSignalingNan());
 }

--- a/vendor/double-conversion/test/cctest/test-strtod.cc
+++ b/vendor/double-conversion/test/cctest/test-strtod.cc
@@ -1,4 +1,29 @@
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
 


### PR DESCRIPTION
This bumps to latest master of double-conversion, which fixes its bazel `BUILD` file