### PR TITLE
Integration into OSS-Fuzz

### DIFF
--- a/fuzzers/fuzz_decode.cpp
+++ b/fuzzers/fuzz_decode.cpp
@@ -1,0 +1,28 @@
+#include <string>
+#include <stdint.h>
+#include <spotify/json/codec/number.hpp>
+#include <spotify/json/codec/object.hpp>
+#include <spotify/json/decode.hpp>
+#include <spotify/json/encoded_value.hpp>
+
+namespace {
+  struct custom_obj {
+    std::string val;
+  };
+}
+
+template <>
+struct spotify::json::default_codec_t<custom_obj> {
+  static codec::object_t<custom_obj> codec() {
+    auto codec = codec::object<custom_obj>();
+    codec.required("x", &custom_obj::val);
+    return codec;
+  }
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  custom_obj obj;
+  std::string input(reinterpret_cast<const char*>(data), size);
+  spotify::json::try_decode(obj, input);
+  return 0;
+}


### PR DESCRIPTION
Hi

I have integrated fuzzing into spotify-json and was thinking that it would be nice to set up continuous fuzzing by way of OSS-Fuzz. In this PR: https://github.com/google/oss-fuzz/pull/5014 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate. In that PR you also see the fuzzer attached, but it would be nicer to have the fuzzer integrated into the upstream project itself rather than keeping it in OSS-Fuzz - so if this PR gets merged I will remove it from OSS-Fuzz

Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

If you would like to integrate, could I please have an email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. Notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file and they also need to be linked with a Google account to get the detailed reports.

David